### PR TITLE
Show a message when there aren't any conflicts to resolve.

### DIFF
--- a/lib/merge-conflicts-view.coffee
+++ b/lib/merge-conflicts-view.coffee
@@ -4,7 +4,7 @@ path = require 'path'
 
 GitBridge = require './git-bridge'
 ConflictMarker = require './conflict-marker'
-{SuccessView, MaybeLaterView} = require './message-views'
+{SuccessView, MaybeLaterView, NothingToMergeView} = require './message-views'
 
 module.exports =
 class MergeConflictsView extends View
@@ -90,13 +90,15 @@ class MergeConflictsView extends View
 
     root = atom.project.getRootDirectory().getRealPathSync()
     GitBridge.conflictsIn root, (conflicts) =>
-      if conflicts
+      if conflicts.length > 0
         view = new MergeConflictsView(conflicts)
         @instance = view
         atom.workspaceView.appendToBottom(view)
 
         atom.workspaceView.eachEditorView (view) =>
           @markConflictsIn conflicts, view if view.attached and view.getPane()?
+      else
+        atom.workspaceView.appendToTop new NothingToMergeView
 
   @markConflictsIn: (conflicts, editorView) ->
     return unless conflicts

--- a/lib/message-views.coffee
+++ b/lib/message-views.coffee
@@ -27,6 +27,15 @@ class SuccessView extends MessageView
     @code 'git commit'
     @text ' at will to finish the merge.'
 
+class NothingToMergeView extends MessageView
+
+  @headingText = 'Nothing to Merge'
+
+  @headingClass = 'info'
+
+  @bodyMarkup: ->
+    @text 'No conflicts here!'
+
 class MaybeLaterView extends MessageView
 
   @headingText = 'Maybe Later'
@@ -38,4 +47,5 @@ class MaybeLaterView extends MessageView
 
 module.exports =
   SuccessView: SuccessView,
-  MaybeLayerView: MaybeLaterView
+  MaybeLayerView: MaybeLaterView,
+  NothingToMergeView: NothingToMergeView


### PR DESCRIPTION
Rather than show an empty `MergeConflictView`, show a `MessageView` telling you there's nothing to do and terminate merge-mode right away. Fixes #21.
