### PR TITLE
Center conflict markers when you jump.

### DIFF
--- a/lib/conflict-marker.coffee
+++ b/lib/conflict-marker.coffee
@@ -217,4 +217,5 @@ class ConflictMarker
 
   focusConflict: (conflict) ->
     st = conflict.ours.marker.getBufferRange().start
-    @editor().setCursorBufferPosition st
+    @editorView.scrollToBufferPosition st, center: true
+    @editor().setCursorBufferPosition st, autoscroll: false


### PR DESCRIPTION
Fixes #23. I'm scrolling to the first line of the "ours" marker, because that seems like a reasonable place to be; I like having some context above the merge.
