### PR TITLE
Don't add borders to .line elements.

### DIFF
--- a/stylesheets/merge-conflicts.less
+++ b/stylesheets/merge-conflicts.less
@@ -116,8 +116,6 @@
   .navigation {
     padding: 0 20px;
     background: @base-background-color;
-    border-left: solid 2px @background-color-highlight;
-    border-right: solid 2px @background-color-highlight;
     width: 100%;
     position: absolute;
     left: 0;


### PR DESCRIPTION
It turns out that they interfere with measurements that happen to position
the cursor correctly, but only if the characters in that row haven't already
been measured and cached.

Fixes #30.
