### PR TITLE
Fix git error using sideview

### DIFF
--- a/lib/merge-conflicts-view.coffee
+++ b/lib/merge-conflicts-view.coffee
@@ -96,9 +96,7 @@ class MergeConflictsView extends View
 
   sideResolver: (side) ->
     (event) ->
-      p = $(event.target).find('.path').text()
-      p = $(event.target).parent()?.find('.path').text() unless p.length>0
-      p = $(event.target).parent()?.parent()?.find('.path').text() unless p.length>0
+      p = $(event.target).closest('li').find('.path').text()
       GitBridge.checkoutSide side, p, ->
         full = path.join atom.project.path, p
         atom.emit 'merge-conflicts:resolved', file: full, total: 1, resolved: 1


### PR DESCRIPTION
Rightclick -> `Resolve. Entire File Ours/Theirs` threw an error when the mouse was not **exactly** at the parental

``` js
@li click: 'navigate', class: 'list-item navigate'
```

item. This patch enables them on the children aswell.
