### PR TITLE
Linux and Windows keybindings

### DIFF
--- a/keymaps/merge-conflicts.cson
+++ b/keymaps/merge-conflicts.cson
@@ -11,15 +11,15 @@
 # Mac OS
 
 '.platform-darwin .editor.conflicted':
-  'cmd-alt-down': 'merge-conflicts:next-unresolved'
-  'cmd-alt-up': 'merge-conflicts:previous-unresolved'
-  'cmd-alt-enter': 'merge-conflicts:accept-current'
-  'cmd-alt-r': 'merge-conflicts:revert-current'
-  'cmd-alt-1': 'merge-conflicts:accept-ours'
-  'cmd-alt-2': 'merge-conflicts:accept-theirs'
+  'cmd-m down': 'merge-conflicts:next-unresolved'
+  'cmd-m up': 'merge-conflicts:previous-unresolved'
+  'cmd-m enter': 'merge-conflicts:accept-current'
+  'cmd-m r': 'merge-conflicts:revert-current'
+  'cmd-m 1': 'merge-conflicts:accept-ours'
+  'cmd-m 2': 'merge-conflicts:accept-theirs'
 
 '.platform-darwin .workspace':
-  'cmd-alt-m': 'merge-conflicts:detect'
+  'cmd-m d': 'merge-conflicts:detect'
 
 # Linux
 


### PR DESCRIPTION
This adds keybindings for Windows and Linux. I'm changing to a `Ctrl-M` prefixed chord sequence, because the `Ctrl-Alt` space is too crowded.
