### PR TITLE
Remove text-error from title of error view

### DIFF
--- a/lib/error-view.coffee
+++ b/lib/error-view.coffee
@@ -6,7 +6,7 @@ class GitNotFoundErrorView extends View
   @content: (err) ->
     @div class: 'overlay from-top padded merge-conflict-error merge-conflicts-message', =>
       @div class: 'panel', =>
-        @div class: "panel-heading text-error", =>
+        @div class: "panel-heading", =>
           @code 'git'
           @text "can't be found at "
           @code atom.config.get 'merge-conflicts.gitPath'


### PR DESCRIPTION
As mentioned in #58, take away color styling in the title of the error view.
