### PR TITLE
Fix the staging dialog styles.

### DIFF
--- a/stylesheets/merge-conflicts.less
+++ b/stylesheets/merge-conflicts.less
@@ -53,7 +53,7 @@
 }
 
 // Temporary React editor workaround.
-.panes .pane .item-views > .react-wrapper > .overlay.resolver {
+.panes .pane .item-views > .react > .overlay.resolver {
   left: 50%;
   padding: 10px;
   bottom: auto;


### PR DESCRIPTION
The React editor changed its markup slightly, so my CSS workaround no longer applied properly:

![screen shot 2014-06-20 at 10 38 26 am](https://cloud.githubusercontent.com/assets/17565/3341477/ca45bcea-f888-11e3-9fdd-9c405ab3d6c5.png)
