### PR TITLE
assume git is in path, works in windows and linux

### DIFF
--- a/lib/merge-conflicts.coffee
+++ b/lib/merge-conflicts.coffee
@@ -12,6 +12,6 @@ module.exports =
   deactivate: ->
 
   configDefaults:
-    gitPath: '/usr/local/bin/git'
+    gitPath: 'git'
 
   serialize: ->


### PR DESCRIPTION
I got crash of atom under windows because I forgot set where is my git. This should fix it. Git should be in PATH.
