### PR TITLE
Depend on space-pen directly.

### DIFF
--- a/lib/conflict-marker.coffee
+++ b/lib/conflict-marker.coffee
@@ -1,4 +1,4 @@
-{$} = require 'atom-space-pen-views'
+{$} = require 'space-pen'
 _ = require 'underscore-plus'
 {Emitter, CompositeDisposable} = require 'atom'
 

--- a/lib/conflict.coffee
+++ b/lib/conflict.coffee
@@ -1,4 +1,4 @@
-{$} = require 'atom-space-pen-views'
+{$} = require 'space-pen'
 {Emitter} = require 'atom'
 
 {Side, OurSide, TheirSide} = require './side'

--- a/lib/covering-view.coffee
+++ b/lib/covering-view.coffee
@@ -1,4 +1,4 @@
-{View, $} = require 'atom-space-pen-views'
+{View, $} = require 'space-pen'
 _ = require 'underscore-plus'
 {EditorAdapter} = require './editor-adapter'
 

--- a/lib/editor-adapter.coffee
+++ b/lib/editor-adapter.coffee
@@ -1,4 +1,4 @@
-{$} = require 'atom-space-pen-views'
+{$} = require 'space-pen'
 _ = require 'underscore-plus'
 
 class EditorAdapter

--- a/lib/error-view.coffee
+++ b/lib/error-view.coffee
@@ -1,4 +1,4 @@
-{View} = require 'atom-space-pen-views'
+{View} = require 'space-pen'
 {GitNotFoundError} = require './git-bridge'
 
 class GitNotFoundErrorView extends View

--- a/lib/merge-conflicts-view.coffee
+++ b/lib/merge-conflicts-view.coffee
@@ -1,4 +1,4 @@
-{$, View} = require 'atom-space-pen-views'
+{$, View} = require 'space-pen'
 {CompositeDisposable} = require 'atom'
 _ = require 'underscore-plus'
 path = require 'path'

--- a/lib/message-views.coffee
+++ b/lib/message-views.coffee
@@ -1,4 +1,4 @@
-{View} = require 'atom-space-pen-views'
+{View} = require 'space-pen'
 
 class MessageView extends View
 

--- a/lib/resolver-view.coffee
+++ b/lib/resolver-view.coffee
@@ -1,5 +1,5 @@
 {CompositeDisposable} = require 'atom'
-{View} = require 'atom-space-pen-views'
+{View} = require 'space-pen'
 {GitBridge} = require './git-bridge'
 handleErr = require './error-view'
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "atom": ">0.50.0"
   },
   "dependencies": {
-    "atom-space-pen-views": "^2.0.3",
+    "space-pen": "^5.0.1",
     "underscore-plus": "1.x"
   }
 }

--- a/spec/conflict-marker-spec.coffee
+++ b/spec/conflict-marker-spec.coffee
@@ -1,4 +1,4 @@
-{$} = require 'atom-space-pen-views'
+{$} = require 'space-pen'
 ConflictMarker = require '../lib/conflict-marker'
 {GitBridge} = require '../lib/git-bridge'
 util = require './util'

--- a/spec/side-view-spec.coffee
+++ b/spec/side-view-spec.coffee
@@ -1,4 +1,4 @@
-{$} = require 'atom-space-pen-views'
+{$} = require 'space-pen'
 SideView = require '../lib/side-view'
 Conflict = require '../lib/conflict'
 util = require './util'


### PR DESCRIPTION
I wasn't actually using "atom-space-pen-views" for anything that wasn't just re-exported from space-pen, so I can just depend on space-pen myself and cut out the middleman. :scissors: 