### PR TITLE
Use Editor instead of EditorView.

### DIFF
--- a/lib/conflict-marker.coffee
+++ b/lib/conflict-marker.coffee
@@ -17,8 +17,6 @@ class ConflictMarker
     @conflicts = Conflict.all(@state, @editor)
 
     @editorView = atom.views.getView @editor
-    @adapter = EditorAdapter.adapt(@editorView)
-
     $(@editorView).addClass 'conflicted' if @conflicts
 
     @coveringViews = []
@@ -174,8 +172,6 @@ class ConflictMarker
         if c.theirs.marker.getBufferRange().containsPoint p
           matching.push c.theirs
     matching
-
-  linesForMarker: (marker) -> @adapter.linesForMarker(marker)
 
   combineSides: (first, second) ->
     text = @editor.getTextInBufferRange second.marker.getBufferRange()

--- a/lib/conflict-marker.coffee
+++ b/lib/conflict-marker.coffee
@@ -16,14 +16,11 @@ class ConflictMarker
 
     @conflicts = Conflict.all(@state, @editor)
 
-    @editorView = atom.views.getView @editor
-    $(@editorView).addClass 'conflicted' if @conflicts
-
     @coveringViews = []
     for c in @conflicts
-      @coveringViews.push new SideView(c.ours, @editorView)
-      @coveringViews.push new NavigationView(c.navigator, @editorView)
-      @coveringViews.push new SideView(c.theirs, @editorView)
+      @coveringViews.push new SideView(c.ours, @editor)
+      @coveringViews.push new NavigationView(c.navigator, @editor)
+      @coveringViews.push new SideView(c.theirs, @editor)
 
       @subs.add c.onDidResolveConflict =>
         unresolved = (v for v in @coveringViews when not v.conflict().isResolved())
@@ -49,14 +46,14 @@ class ConflictMarker
     @subs.add @editor.onDidStopChanging => @detectDirty()
     @subs.add @editor.onDidDestroy => @cleanup()
 
-    @subs.add atom.commands.add 'atom-text-editor.conflicted', 'merge-conflicts:accept-current', => @acceptCurrent()
-    @subs.add atom.commands.add 'atom-text-editor.conflicted', 'merge-conflicts:accept-ours', => @acceptOurs()
-    @subs.add atom.commands.add 'atom-text-editor.conflicted', 'merge-conflicts:accept-theirs', => @acceptTheirs()
-    @subs.add atom.commands.add 'atom-text-editor.conflicted', 'merge-conflicts:ours-then-theirs', => @acceptOursThenTheirs()
-    @subs.add atom.commands.add 'atom-text-editor.conflicted', 'merge-conflicts:theirs-then-ours', => @acceptTheirsThenOurs()
-    @subs.add atom.commands.add 'atom-text-editor.conflicted', 'merge-conflicts:next-unresolved', => @nextUnresolved()
-    @subs.add atom.commands.add 'atom-text-editor.conflicted', 'merge-conflicts:previous-unresolved', => @previousUnresolved()
-    @subs.add atom.commands.add 'atom-text-editor.conflicted', 'merge-conflicts:revert-current', => @revertCurrent()
+    @subs.add atom.commands.add 'atom-text-editor', 'merge-conflicts:accept-current', => @acceptCurrent()
+    @subs.add atom.commands.add 'atom-text-editor', 'merge-conflicts:accept-ours', => @acceptOurs()
+    @subs.add atom.commands.add 'atom-text-editor', 'merge-conflicts:accept-theirs', => @acceptTheirs()
+    @subs.add atom.commands.add 'atom-text-editor', 'merge-conflicts:ours-then-theirs', => @acceptOursThenTheirs()
+    @subs.add atom.commands.add 'atom-text-editor', 'merge-conflicts:theirs-then-ours', => @acceptTheirsThenOurs()
+    @subs.add atom.commands.add 'atom-text-editor', 'merge-conflicts:next-unresolved', => @nextUnresolved()
+    @subs.add atom.commands.add 'atom-text-editor', 'merge-conflicts:previous-unresolved', => @previousUnresolved()
+    @subs.add atom.commands.add 'atom-text-editor', 'merge-conflicts:revert-current', => @revertCurrent()
 
     @subs.add atom.emitter.on 'merge-conflicts:resolved', ({total, resolved, file}) =>
       if file is @editor.getPath() and total is resolved
@@ -65,7 +62,6 @@ class ConflictMarker
   cleanup: ->
     @subs.dispose()
     v.remove() for v in @coveringViews
-    $(@editorView).removeClass 'conflicted'
 
   conflictsResolved: ->
     @cleanup()

--- a/lib/covering-view.coffee
+++ b/lib/covering-view.coffee
@@ -5,7 +5,8 @@ _ = require 'underscore-plus'
 
 class CoveringView extends View
 
-  initialize: (@editorView) ->
+  initialize: (@editor) ->
+    @editorView = atom.views.getView @editor
     @adapter = EditorAdapter.adapt(@editorView)
 
     @adapter.append(this)
@@ -30,34 +31,28 @@ class CoveringView extends View
   getModel: -> null
 
   reposition: ->
-    # FIXME this is a workaround for a TextEditorView bug.
-    # https://github.com/atom/atom/pull/3517
-    @editorView.component.checkForVisibilityChange()
-
     marker = @cover()
     anchor = $(@editorView).offset()
     ref = @offsetForMarker marker
-    scrollTop = @editor().getScrollTop()
+    scrollTop = @editor.getScrollTop()
 
     @offset top: ref.top + anchor.top - scrollTop
-    @height @editor().getLineHeightInPixels()
+    @height @editor.getLineHeightInPixels()
 
-  editor: -> @editorView.getModel()
-
-  buffer: -> @editor().getBuffer()
+  buffer: -> @editor.getBuffer()
 
   includesCursor: (cursor) -> false
 
   offsetForMarker: (marker) ->
     position = marker.getTailBufferPosition()
-    @editor().pixelPositionForBufferPosition position
+    @editor.pixelPositionForBufferPosition position
 
   deleteMarker: (marker) ->
     @buffer().delete marker.getBufferRange()
     marker.destroy()
 
   scrollTo: (positionOrNull) ->
-    @editor().setCursorBufferPosition positionOrNull if positionOrNull?
+    @editor.setCursorBufferPosition positionOrNull if positionOrNull?
 
   prependKeystroke: (eventName, element) ->
     bindings = atom.keymap.findKeyBindings

--- a/lib/merge-conflicts-view.coffee
+++ b/lib/merge-conflicts-view.coffee
@@ -155,5 +155,4 @@ class MergeConflictsView extends View
     repoPath = atom.project.getRepositories()[0].relativize fullPath
     return unless _.contains state.conflictPaths(), repoPath
 
-    editorView = atom.views.getView editor
-    new ConflictMarker(state, editorView)
+    new ConflictMarker(state, editor)

--- a/lib/merge-conflicts-view.coffee
+++ b/lib/merge-conflicts-view.coffee
@@ -84,14 +84,14 @@ class MergeConflictsView extends View
       # Any files that were present, but aren't there any more, have been
       # resolved.
       for item in @pathList.find('li')
-        p = $(item).find('.path').text()
+        p = $(item).data('path')
         icon = $(item).find('.staged')
         icon.removeClass 'icon-dash icon-check text-success'
         if _.contains @state.conflictPaths(), p
           icon.addClass 'icon-dash'
         else
           icon.addClass 'icon-check text-success'
-          @pathList.find("li:contains('#{p}') .stage-ready").eq(0).hide()
+          @pathList.find("li[data-path='#{p}'] .stage-ready").hide()
 
       if @state.isEmpty()
         atom.emitter.emit 'merge-conflicts:done'
@@ -110,7 +110,7 @@ class MergeConflictsView extends View
 
   sideResolver: (side) ->
     (event) ->
-      p = $(event.target).closest('li').find('.path').text()
+      p = $(event.target).closest('li').data('path')
       GitBridge.checkoutSide side, p, (err) ->
         return if handleErr(err)
 
@@ -119,7 +119,7 @@ class MergeConflictsView extends View
         atom.workspace.open p
 
   stageFile: (event, element) ->
-    repoPath = element.closest('li').find('.path').text()
+    repoPath = element.closest('li').data('path')
     filePath = path.join atom.project.getRepositories()[0].getWorkingDirectory(), repoPath
 
     for e in atom.workspace.getTextEditors()

--- a/lib/merge-conflicts.coffee
+++ b/lib/merge-conflicts.coffee
@@ -1,8 +1,5 @@
 {CompositeDisposable} = require 'atom'
 MergeConflictsView = require './merge-conflicts-view'
-SideView = require './side-view'
-NavigationView = require './navigation-view'
-Conflict = require './conflict'
 {GitBridge} = require './git-bridge'
 handleErr = require './error-view'
 

--- a/lib/navigation-view.coffee
+++ b/lib/navigation-view.coffee
@@ -4,15 +4,15 @@
 module.exports =
 class NavigationView extends CoveringView
 
-  @content: (navigator, editorView) ->
+  @content: (navigator, editor) ->
     @div class: 'controls navigation', =>
       @text ' '
       @span class: 'pull-right', =>
         @button class: 'btn btn-xs', click: 'up', outlet: 'prevBtn', 'prev'
         @button class: 'btn btn-xs', click: 'down', outlet: 'nextBtn', 'next'
 
-  initialize: (@navigator, editorView) ->
-    super editorView
+  initialize: (@navigator, editor) ->
+    super editor
     @subs = new CompositeDisposable
 
     @prependKeystroke 'merge-conflicts:previous-unresolved', @prevBtn

--- a/lib/resolver-view.coffee
+++ b/lib/resolver-view.coffee
@@ -24,7 +24,7 @@ class ResolverView extends View
     @subs = new CompositeDisposable()
 
     @refresh()
-    @editor.onDidSave => @refresh()
+    @subs.add @editor.onDidSave => @refresh()
 
     @subs.add atom.commands.add @element, 'merge-conflicts:quit', => @dismiss()
 

--- a/lib/side-view.coffee
+++ b/lib/side-view.coffee
@@ -4,7 +4,7 @@
 module.exports =
 class SideView extends CoveringView
 
-  @content: (side, editorView) ->
+  @content: (side, editor) ->
     @div class: "side #{side.klass()} #{side.position} ui-site-#{side.site()}", =>
       @div class: 'controls', =>
         @label class: 'text-highlight', side.ref
@@ -13,8 +13,8 @@ class SideView extends CoveringView
           @button class: 'btn btn-xs inline-block-tight revert', click: 'revert', outlet: 'revertBtn', 'Revert'
           @button class: 'btn btn-xs inline-block-tight', click: 'useMe', outlet: 'useMeBtn', 'Use Me'
 
-  initialize: (@side, editorView) ->
-    super editorView
+  initialize: (@side, editor) ->
+    super editor
     @subs = new CompositeDisposable
 
     @decoration = null
@@ -37,7 +37,7 @@ class SideView extends CoveringView
       type: 'line'
       class: @side.lineClass()
     @decoration.destroy() if @decoration?
-    @decoration = @editor().decorateMarker(@side.marker, args)
+    @decoration = @editor.decorateMarker(@side.marker, args)
 
   conflict: -> @side.conflict
 
@@ -54,12 +54,11 @@ class SideView extends CoveringView
     @decorate()
 
   revert: ->
-    @editor().setTextInBufferRange @side.marker.getBufferRange(),
-      @side.originalText
+    @editor.setTextInBufferRange @side.marker.getBufferRange(), @side.originalText
     @decorate()
 
   detectDirty: ->
-    currentText = @editor().getTextInBufferRange @side.marker.getBufferRange()
+    currentText = @editor.getTextInBufferRange @side.marker.getBufferRange()
     @side.isDirty = currentText isnt @side.originalText
 
     @decorate()

--- a/spec/conflict-marker-spec.coffee
+++ b/spec/conflict-marker-spec.coffee
@@ -33,7 +33,7 @@ describe 'ConflictMarker', ->
         state =
           isRebase: false
 
-        m = new ConflictMarker(state, editorView)
+        m = new ConflictMarker(state, editor)
 
     it 'attaches two SideViews and a NavigationView for each conflict', ->
       expect($(editorView).find('.side').length).toBe(6)
@@ -55,7 +55,6 @@ describe 'ConflictMarker', ->
       expect(lines.hasClass 'conflict-theirs').toBe(true)
 
     it 'applies the "dirty" class to modified sides', ->
-      editor = editorView.getModel()
       editor.setCursorBufferPosition [14, 0]
       editor.insertText "Make conflict 1 dirty"
       detectDirty()
@@ -69,15 +68,15 @@ describe 'ConflictMarker', ->
       atom.emitter.on 'merge-conflicts:resolved', (e) -> event = e
       m.conflicts[2].theirs.resolve()
 
-      expect(event.file).toBe(editorView.getModel().getPath())
+      expect(event.file).toBe(editor.getPath())
       expect(event.total).toBe(3)
       expect(event.resolved).toBe(1)
       expect(event.source).toBe(m)
 
     it 'tracks the active conflict side', ->
-      editorView.getModel().setCursorBufferPosition [11, 0]
+      editor.setCursorBufferPosition [11, 0]
       expect(m.active()).toEqual([])
-      editorView.getModel().setCursorBufferPosition [14, 5]
+      editor.setCursorBufferPosition [14, 5]
       expect(m.active()).toEqual([m.conflicts[1].ours])
 
     describe 'with an active merge conflict', ->
@@ -182,7 +181,7 @@ describe 'ConflictMarker', ->
         state =
           isRebase: true
 
-        m = new ConflictMarker(state, editorView)
+        m = new ConflictMarker(state, editor)
 
         editor.setCursorBufferPosition [3, 14]
         active = m.conflicts[0]

--- a/spec/conflict-marker-spec.coffee
+++ b/spec/conflict-marker-spec.coffee
@@ -52,9 +52,6 @@ describe 'ConflictMarker', ->
       expect($(editorView).find('.side').length).toBe(6)
       expect($(editorView).find('.navigation').length).toBe(3)
 
-    it 'adds the conflicted class', ->
-      expect($(editorView).hasClass 'conflicted').toBe(true)
-
     it 'locates the correct lines', ->
       lines = linesForMarker m.conflicts[1].ours.marker
       expect(lines.text()).toBe("My middle changes")

--- a/spec/conflict-marker-spec.coffee
+++ b/spec/conflict-marker-spec.coffee
@@ -1,4 +1,6 @@
 {$} = require 'space-pen'
+_ = require 'underscore-plus'
+
 ConflictMarker = require '../lib/conflict-marker'
 {GitBridge} = require '../lib/git-bridge'
 util = require './util'
@@ -11,6 +13,17 @@ describe 'ConflictMarker', ->
   detectDirty = ->
     for sv in m.coveringViews
       sv.detectDirty() if 'detectDirty' of sv
+
+  linesForMarker = (marker) ->
+    fromBuffer = marker.getTailBufferPosition()
+    fromScreen = editor.screenPositionForBufferPosition fromBuffer
+    toBuffer = marker.getHeadBufferPosition()
+    toScreen = editor.screenPositionForBufferPosition toBuffer
+
+    result = $()
+    for row in _.range(fromScreen.row, toScreen.row)
+      result = result.add editorView.component.lineNodeForScreenRow(row)
+    result
 
   beforeEach ->
     done = false
@@ -43,15 +56,15 @@ describe 'ConflictMarker', ->
       expect($(editorView).hasClass 'conflicted').toBe(true)
 
     it 'locates the correct lines', ->
-      lines = m.linesForMarker m.conflicts[1].ours.marker
+      lines = linesForMarker m.conflicts[1].ours.marker
       expect(lines.text()).toBe("My middle changes")
 
     it 'applies the "ours" class to our sides of conflicts', ->
-      lines = m.linesForMarker m.conflicts[0].ours.marker
+      lines = linesForMarker m.conflicts[0].ours.marker
       expect(lines.hasClass 'conflict-ours').toBe(true)
 
     it 'applies the "theirs" class to their sides of conflicts', ->
-      lines = m.linesForMarker m.conflicts[0].theirs.marker
+      lines = linesForMarker m.conflicts[0].theirs.marker
       expect(lines.hasClass 'conflict-theirs').toBe(true)
 
     it 'applies the "dirty" class to modified sides', ->
@@ -59,7 +72,7 @@ describe 'ConflictMarker', ->
       editor.insertText "Make conflict 1 dirty"
       detectDirty()
 
-      lines = m.linesForMarker m.conflicts[1].ours.marker
+      lines = linesForMarker m.conflicts[1].ours.marker
       expect(lines.hasClass 'conflict-dirty').toBe(true)
       expect(lines.hasClass 'conflict-ours').toBe(false)
 

--- a/spec/navigation-view-spec.coffee
+++ b/spec/navigation-view-spec.coffee
@@ -13,7 +13,7 @@ describe 'NavigationView', ->
       conflicts = Conflict.all({}, editor)
       conflict = conflicts[1]
 
-      view = new NavigationView(conflict.navigator, editorView)
+      view = new NavigationView(conflict.navigator, editor)
 
   it 'deletes the separator line on resolution', ->
     c.ours.resolve() for c in conflicts

--- a/spec/side-view-spec.coffee
+++ b/spec/side-view-spec.coffee
@@ -10,10 +10,11 @@ describe 'SideView', ->
 
   beforeEach ->
     util.openPath "single-2way-diff.txt", (v) ->
+      editor = v.getModel()
       editorView = v
-      conflict = Conflict.all({ isRebase: false }, editorView.getModel())[0]
+      conflict = Conflict.all({ isRebase: false }, editor)[0]
       [ours, theirs] = [conflict.ours, conflict.theirs]
-      view = new SideView(ours, editorView)
+      view = new SideView(ours, editor)
 
   it 'applies its position as a CSS class', ->
     expect(view.hasClass 'top').toBe(true)


### PR DESCRIPTION
Because there's now an easy way to get a view from a model:

```coffeescript
view = atom.views.getView model
```

... I can get rid of all of the places where I'm awkwardly carrying around both, or passing the view around and yanking the model out when I need it.