### PR TITLE
Pass package around properly.

### DIFF
--- a/lib/merge-conflicts-view.coffee
+++ b/lib/merge-conflicts-view.coffee
@@ -143,12 +143,12 @@ class MergeConflictsView extends View
         atom.workspace.addBottomPanel item: view
 
         @instance.subs.add atom.workspace.observeTextEditors (editor) =>
-          marker = @markConflictsIn state, editor
+          marker = @markConflictsIn state, editor, pkg
           @instance.markers.push marker if marker?
       else
         atom.workspace.addTopPanel item: new NothingToMergeView(state)
 
-  @markConflictsIn: (state, editor) ->
+  @markConflictsIn: (state, editor, pkg) ->
     return if state.isEmpty()
 
     fullPath = editor.getPath()

--- a/lib/merge-conflicts.coffee
+++ b/lib/merge-conflicts.coffee
@@ -10,13 +10,13 @@ module.exports =
     @emitter = new Emitter
 
     pkgEmitter =
-      onDidResolveConflict: @onDidResolveConflict
+      onDidResolveConflict: (callback) => @onDidResolveConflict(callback)
       didResolveConflict: (event) => @emitter.emit 'did-resolve-conflict', event
-      onDidStageFile: @onDidStageFile
+      onDidStageFile: (callback) => @onDidStageFile(callback)
       didStageFile: (event) => @emitter.emit 'did-stage-file', event
-      onDidQuitConflictResolution: @onDidQuitConflictResolution
+      onDidQuitConflictResolution: (callback) => @onDidQuitConflictResolution(callback)
       didQuitConflictResolution: => @emitter.emit 'did-quit-conflict-resolution'
-      onDidCompleteConflictResolution: @onDidCompleteConflictResolution
+      onDidCompleteConflictResolution: (callback) => @onDidCompleteConflictResolution(callback)
       didCompleteConflictResolution: => @emitter.emit 'did-complete-conflict-resolution'
 
     @subs.add atom.commands.add 'atom-workspace', 'merge-conflicts:detect', ->


### PR DESCRIPTION
The specs weren't catching this because they didn't use the top-level `detect()` method to set things up.