### PR TITLE
Control subscription cleanup in CoveringViews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.10
+
+- Control subscription cleanup in CoveringViews. [#123](https://github.com/smashwilson/merge-conflicts/pull/123)
+
 ## 1.2.9
 
 - It actually works again :wink:

--- a/docs/useful-test-cases.md
+++ b/docs/useful-test-cases.md
@@ -1,0 +1,7 @@
+# Ansible core
+
+git checkout 7806c50
+git merge 4e0c01b
+
+git checkout 3a015a7
+git merge 6676720

--- a/lib/covering-view.coffee
+++ b/lib/covering-view.coffee
@@ -1,3 +1,4 @@
+{CompositeDisposable} = require 'atom'
 {View, $} = require 'space-pen'
 _ = require 'underscore-plus'
 
@@ -5,10 +6,13 @@ _ = require 'underscore-plus'
 class CoveringView extends View
 
   initialize: (@editor) ->
-    @decoration = @editor.decorateMarker @cover(),
+    @coverSubs = new CompositeDisposable
+    @overlay = @editor.decorateMarker @cover(),
       type: 'overlay',
       item: this,
       position: 'tail'
+
+    @coverSubs.add @editor.onDidDestroy => @cleanup()
 
   attached: ->
     rightPosition = if @editor.verticallyScrollable()
@@ -21,8 +25,11 @@ class CoveringView extends View
     @css 'margin-top': -@editor.getLineHeightInPixels()
     @height @editor.getLineHeightInPixels()
 
-  remove: ->
-    @decoration.destroy()
+  cleanup: ->
+    @coverSubs.dispose()
+
+    @overlay?.destroy()
+    @overlay = null
 
   # Override to specify the marker of the first line that should be covered.
   cover: -> null

--- a/lib/navigation-view.coffee
+++ b/lib/navigation-view.coffee
@@ -20,9 +20,12 @@ class NavigationView extends CoveringView
 
     @subs.add @navigator.conflict.onDidResolveConflict =>
       @deleteMarker @cover()
-      @hide()
+      @remove()
+      @cleanup()
 
-  detached: -> @subs.dispose()
+  cleanup: ->
+    super
+    @subs.dispose()
 
   cover: -> @navigator.separatorMarker
 

--- a/lib/navigation-view.coffee
+++ b/lib/navigation-view.coffee
@@ -12,8 +12,9 @@ class NavigationView extends CoveringView
         @button class: 'btn btn-xs', click: 'down', outlet: 'nextBtn', 'next'
 
   initialize: (@navigator, editor) ->
-    super editor
     @subs = new CompositeDisposable
+
+    super editor
 
     @prependKeystroke 'merge-conflicts:previous-unresolved', @prevBtn
     @prependKeystroke 'merge-conflicts:next-unresolved', @nextBtn

--- a/lib/side-view.coffee
+++ b/lib/side-view.coffee
@@ -14,9 +14,10 @@ class SideView extends CoveringView
           @button class: 'btn btn-xs inline-block-tight', click: 'useMe', outlet: 'useMeBtn', 'Use Me'
 
   initialize: (@side, editor) ->
-    super editor
     @subs = new CompositeDisposable
     @decoration = null
+
+    super editor
 
     @detectDirty()
     @prependKeystroke @side.eventName(), @useMeBtn

--- a/lib/side-view.coffee
+++ b/lib/side-view.coffee
@@ -16,19 +16,25 @@ class SideView extends CoveringView
   initialize: (@side, editor) ->
     super editor
     @subs = new CompositeDisposable
-
     @decoration = null
 
     @detectDirty()
     @prependKeystroke @side.eventName(), @useMeBtn
     @prependKeystroke 'merge-conflicts:revert-current', @revertBtn
 
+  attached: ->
+    super
+
+    @decorate()
     @subs.add @side.conflict.onDidResolveConflict =>
       @deleteMarker @side.refBannerMarker
       @deleteMarker @side.marker unless @side.wasChosen()
       @remove()
+      @cleanup()
 
-  detached: -> @subs.dispose()
+  cleanup: ->
+    super
+    @subs.dispose()
 
   cover: -> @side.refBannerMarker
 


### PR DESCRIPTION
CoveringViews were cleaning up their event subscriptions in a `detached` hook. Unfortunately, an overlay decoration is detached from the DOM every time it scrolls off of the page!

This implements cleanup logic in a `cleanup` method which is explicitly invoked when the view is dismissed, or the TextEditor is destroyed.

Re #121