### PR TITLE
Handle next or previous conflict navigation past the end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.1
+
+- Handle next-unresolved or previous-unresolved navigation when conflicts exist in that direction, but all are resolved. [#135](https://github.com/smashwilson/merge-conflicts/pull/135)
+
 ## 1.3.0
 
 - Fix more deprecation warnings. [#132](https://github.com/smashwilson/merge-conflicts/pull/132)

--- a/lib/conflict-marker.coffee
+++ b/lib/conflict-marker.coffee
@@ -163,6 +163,8 @@ class ConflictMarker
         target = lastBefore.navigator.previousUnresolved()
       else
         target = lastBefore
+      return unless target?
+
       @focusConflict target
 
   revertCurrent: ->

--- a/lib/conflict-marker.coffee
+++ b/lib/conflict-marker.coffee
@@ -137,6 +137,8 @@ class ConflictMarker
         target = firstAfter.navigator.nextUnresolved()
       else
         target = firstAfter
+      return unless target?
+
       @focusConflict target
 
   previousUnresolved: ->


### PR DESCRIPTION
If you invoke `merge-conflicts:next-unresolved` or `merge-conflicts:previous-unresolved` with:

 1. No "active" conflict (meaning you have no cursors in a conflict area)
 2. Conflicts exist in the requested navigation direction, but all of them have been resolved

Then the `ConflictMarker` will attempt to scroll you to a null target, which throws a stack trace.

Fixes #133.