### PR TITLE
Clean up resolved markers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 1.3.1
 
+- Clean up all markers when conflict detection is completed or quit. [#136](https://github.com/smashwilson/merge-conflicts/pull/136)
 - Handle next-unresolved or previous-unresolved navigation when conflicts exist in that direction, but all are resolved. [#135](https://github.com/smashwilson/merge-conflicts/pull/135)
 
 ## 1.3.0

--- a/lib/conflict-marker.coffee
+++ b/lib/conflict-marker.coffee
@@ -60,14 +60,24 @@ class ConflictMarker
       if file is @editor.getPath() and total is resolved
         @conflictsResolved()
 
+    @subs.add @pkg.onDidCompleteConflictResolution => @shutdown()
+    @subs.add @pkg.onDidQuitConflictResolution => @shutdown()
+
   cleanup: ->
     atom.views.getView(@editor).classList.remove 'conflicted'
-    @subs.dispose()
     v.remove() for v in @coveringViews
 
   conflictsResolved: ->
     @cleanup()
     atom.workspace.addTopPanel item: new ResolverView(@editor, @pkg)
+
+  # Public: The package is shutting down, either because everything has been resolved or the user
+  # is quitting prematurely.
+  #
+  shutdown: ->
+    for c in @conflicts
+      m.destroy() for m in c.markers()
+    @subs.dispose()
 
   detectDirty: ->
     # Only detect dirty regions within CoveringViews that have a cursor within them.

--- a/lib/conflict.coffee
+++ b/lib/conflict.coffee
@@ -1,5 +1,6 @@
 {$} = require 'space-pen'
 {Emitter} = require 'atom'
+_ = require 'underscore-plus'
 
 {Side, OurSide, TheirSide} = require './side'
 Navigator = require './navigator'
@@ -115,6 +116,9 @@ class Conflict
     @emitter.emit 'resolve-conflict'
 
   scrollTarget: -> @ours.marker.getTailBufferPosition()
+
+  markers: ->
+    _.flatten [@ours.markers(), @theirs.markers(), @navigator.markers()], true
 
   toString: -> "[conflict: #{@ours} #{@theirs}]"
 

--- a/lib/navigator.coffee
+++ b/lib/navigator.coffee
@@ -19,3 +19,5 @@ class Navigator
     while current? and current.isResolved()
       current = current.navigator.previous
     current
+
+  markers: -> [@separatorMarker]

--- a/lib/side.coffee
+++ b/lib/side.coffee
@@ -16,6 +16,8 @@ class Side
     else
       "conflict-#{@klass()}"
 
+  markers: -> [@marker, @refBannerMarker]
+
   toString: ->
     text = @originalText.replace(/[\n\r]/, ' ')
     if text.length > 20

--- a/spec/conflict-marker-spec.coffee
+++ b/spec/conflict-marker-spec.coffee
@@ -183,6 +183,17 @@ describe 'ConflictMarker', ->
         workspaceView = atom.views.getView atom.workspace
         expect($(workspaceView).find('.resolver').length).toBe(1)
 
+    describe 'when all resolutions are complete', ->
+
+      beforeEach ->
+        c.ours.resolve() for c in m.conflicts
+        pkg.didCompleteConflictResolution()
+
+      it 'destroys all Conflict markers', ->
+        for c in m.conflicts
+          for marker in c.markers()
+            expect(marker.isDestroyed()).toBe(true)
+
   describe 'with a rebase conflict', ->
     [active] = []
 

--- a/spec/conflict-marker-spec.coffee
+++ b/spec/conflict-marker-spec.coffee
@@ -39,6 +39,8 @@ describe 'ConflictMarker', ->
   afterEach ->
     pkg.dispose()
 
+    m?.shutdown()
+
   describe 'with a merge conflict', ->
 
     beforeEach ->
@@ -186,7 +188,7 @@ describe 'ConflictMarker', ->
     describe 'when all resolutions are complete', ->
 
       beforeEach ->
-        c.ours.resolve() for c in m.conflicts
+        c.theirs.resolve() for c in m.conflicts
         pkg.didCompleteConflictResolution()
 
       it 'destroys all Conflict markers', ->


### PR DESCRIPTION
When conflict detection is either completed or exited, clean up any remaining markers.

Fixes #131.