### PR TITLE
Wrong sort of arrows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.2
+
+- Fix a stacktrace when resolving entire files as ours or theirs. [#137](https://github.com/smashwilson/merge-conflicts/pull/137)
+
 ## 1.3.1
 
 - Clean up all markers when conflict detection is completed or quit. [#136](https://github.com/smashwilson/merge-conflicts/pull/136)

--- a/lib/merge-conflicts-view.coffee
+++ b/lib/merge-conflicts-view.coffee
@@ -109,9 +109,9 @@ class MergeConflictsView extends View
     atom.workspace.addTopPanel item: new viewClass(@state)
 
   sideResolver: (side) ->
-    (event) ->
+    (event) =>
       p = $(event.target).closest('li').data('path')
-      GitBridge.checkoutSide side, p, (err) ->
+      GitBridge.checkoutSide side, p, (err) =>
         return if handleErr(err)
 
         full = path.join atom.project.getPaths()[0], p


### PR DESCRIPTION
We need to use `=>` in `MergeConflictsView.sideResover` to reference `@pkg` properly.

Fixes #117.