### PR TITLE
Apply clearfix to merge conflicts panel

### DIFF
--- a/lib/merge-conflicts-view.coffee
+++ b/lib/merge-conflicts-view.coffee
@@ -15,7 +15,7 @@ class MergeConflictsView extends View
   instance: null
 
   @content: (state, pkg) ->
-    @div class: 'merge-conflicts tool-panel panel-bottom padded', =>
+    @div class: 'merge-conflicts tool-panel panel-bottom padded clearfix', =>
       @div class: 'panel-heading', =>
         @text 'Conflicts'
         @span class: 'pull-right icon icon-fold', click: 'minimize', 'Hide'


### PR DESCRIPTION
Necessary because the Quit button is floated right.

Before:

![screen shot 2015-06-05 at 11 20 34](https://cloud.githubusercontent.com/assets/23947/8004139/f1a1c482-0b74-11e5-9045-b49a9bbe421f.png)

After:

![screen shot 2015-06-05 at 11 21 30](https://cloud.githubusercontent.com/assets/23947/8004163/0f6e26c2-0b75-11e5-8ba3-a0d1deea9582.png)
