### PR TITLE
Use alt-M instead of ctrl-M in the keymap.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 1.3.3
 
+- Use alt-m instead of ctrl-m in key bindings. [#162](https://github.com/smashwilson/merge-conflicts/pull/162)
 - Use Atom's built-in notification API. [#151](https://github.com/smashwilson/merge-conflicts/pull/151)
 
 ## 1.3.2

--- a/keymaps/merge-conflicts.cson
+++ b/keymaps/merge-conflicts.cson
@@ -9,12 +9,12 @@
 # https://atom.io/docs/latest/advanced/keymaps
 
 'atom-text-editor.conflicted':
-  'ctrl-m down': 'merge-conflicts:next-unresolved'
-  'ctrl-m up': 'merge-conflicts:previous-unresolved'
-  'ctrl-m enter': 'merge-conflicts:accept-current'
-  'ctrl-m r': 'merge-conflicts:revert-current'
-  'ctrl-m 1': 'merge-conflicts:accept-ours'
-  'ctrl-m 2': 'merge-conflicts:accept-theirs'
+  'alt-m down': 'merge-conflicts:next-unresolved'
+  'alt-m up': 'merge-conflicts:previous-unresolved'
+  'alt-m enter': 'merge-conflicts:accept-current'
+  'alt-m r': 'merge-conflicts:revert-current'
+  'alt-m 1': 'merge-conflicts:accept-ours'
+  'alt-m 2': 'merge-conflicts:accept-theirs'
 
 'atom-workspace':
-  'ctrl-m d': 'merge-conflicts:detect'
+  'alt-m d': 'merge-conflicts:detect'


### PR DESCRIPTION
Ctrl-M conflicts with bracket matcher.

Fixes #157.