### PR TITLE
Correct the "git not found" error view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 1.3.3
 
+- Improve the "Git not found" error dialog. [#163](https://github.com/smashwilson/merge-conflicts/pull/163)
 - Use alt-m instead of ctrl-m in key bindings. [#162](https://github.com/smashwilson/merge-conflicts/pull/162)
 - Use Atom's built-in notification API. [#151](https://github.com/smashwilson/merge-conflicts/pull/151)
 

--- a/lib/git-bridge.coffee
+++ b/lib/git-bridge.coffee
@@ -42,6 +42,9 @@ class GitBridge
         callback(null)
         return
 
+      errorHandler()
+
+    errorHandler = (e) =>
       possiblePath = search.shift()
 
       unless possiblePath?
@@ -53,13 +56,15 @@ class GitBridge
         command: possiblePath,
         args: ['--version'],
         exit: exitHandler
-      })
+      }).onWillThrowError errorHandler
+
+      e?.handle()
 
     @process({
       command: possiblePath,
       args: ['--version'],
       exit: exitHandler
-    })
+    }).onWillThrowError errorHandler
 
   @getActivePath: ->
     atom.workspace.getActivePaneItem()?.getPath?()

--- a/lib/git-bridge.coffee
+++ b/lib/git-bridge.coffee
@@ -45,6 +45,12 @@ class GitBridge
       errorHandler()
 
     errorHandler = (e) =>
+      if e?
+        e.handle()
+
+        # Suppress the default ENOENT handler
+        e.error.code = "NOTENOENT"
+
       possiblePath = search.shift()
 
       unless possiblePath?
@@ -57,8 +63,6 @@ class GitBridge
         args: ['--version'],
         exit: exitHandler
       }).onWillThrowError errorHandler
-
-      e?.handle()
 
     @process({
       command: possiblePath,

--- a/lib/view/error-view.coffee
+++ b/lib/view/error-view.coffee
@@ -19,7 +19,7 @@ class GitNotFoundErrorView extends View
             @button class: 'btn inline-block-tight', click: 'notRightNow', 'Not Right Now'
 
   openSettings: ->
-    atom.workspace.open 'atom://config'
+    atom.workspace.open 'atom://config/packages'
     @remove()
 
   notRightNow: ->

--- a/lib/view/error-view.coffee
+++ b/lib/view/error-view.coffee
@@ -6,17 +6,28 @@ class GitNotFoundErrorView extends View
   @content: (err) ->
     @div class: 'overlay from-top padded merge-conflict-error merge-conflicts-message', =>
       @div class: 'panel', =>
-        @div class: "panel-heading", =>
+        @div class: 'panel-heading no-path', =>
+          @code 'git'
+          @text "can't be found in any of the default locations!"
+        @div class: 'panel-heading wrong-path', =>
           @code 'git'
           @text "can't be found at "
           @code atom.config.get 'merge-conflicts.gitPath'
           @text '!'
         @div class: 'panel-body', =>
           @div class: 'block',
-            'Please fix the path in your settings.'
+            'Please specify the correct path in the merge-conflicts package settings.'
           @div class: 'block', =>
             @button class: 'btn btn-error inline-block-tight', click: 'openSettings', 'Open Settings'
             @button class: 'btn inline-block-tight', click: 'notRightNow', 'Not Right Now'
+
+  initialize: (err) ->
+    if atom.config.get 'merge-conflicts.gitPath'
+      @find('.no-path').hide()
+      @find('.wrong-path').show()
+    else
+      @find('.no-path').show()
+      @find('.wrong-path').hide()
 
   openSettings: ->
     atom.workspace.open 'atom://config/packages'

--- a/lib/view/error-view.coffee
+++ b/lib/view/error-view.coffee
@@ -30,7 +30,7 @@ module.exports =
     return false unless err?
 
     if err instanceof GitNotFoundError
-      atom.workspaceView.appendToTop new GitNotFoundErrorView(err)
-
-    console.error err
+      atom.workspace.addTopPanel item: new GitNotFoundErrorView(err)
+    else
+      console.error err
     true


### PR DESCRIPTION
I missed a deprecated call in the "git not found" error view. While I'm at it:

- [x] Handle BufferedProcess errors with `onWillThrowError` and suppress the default error notification.
- [x] Make the dialog more useful if you don't have any git path set at all.

Fixes #148.