### PR TITLE
Handle projects without git repositories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 1.3.3
 
+- Handle projects with no git repository. [#164](https://github.com/smashwilson/merge-conflicts/pull/164)
 - Improve the "Git not found" error dialog. [#163](https://github.com/smashwilson/merge-conflicts/pull/163)
 - Use alt-m instead of ctrl-m in key bindings. [#162](https://github.com/smashwilson/merge-conflicts/pull/162)
 - Use Atom's built-in notification API. [#151](https://github.com/smashwilson/merge-conflicts/pull/151)

--- a/lib/git-bridge.coffee
+++ b/lib/git-bridge.coffee
@@ -73,8 +73,8 @@ class GitBridge
   @_getActivePath: ->
     atom.workspace.getActivePaneItem()?.getPath?()
 
-  @_getActiveRepo: ->
-    [rootDir] = atom.project.relativizePath @_getActivePath()
+  @getActiveRepo: (filepath) ->
+    [rootDir] = atom.project.relativizePath(filepath or @_getActivePath())
     if rootDir?
       rootDirIndex = atom.project.getPaths().indexOf(rootDir)
       repo = atom.project.getRepositories()[rootDirIndex]
@@ -82,9 +82,9 @@ class GitBridge
       repo = atom.project.getRepositories()[0]
     return repo
 
-  @_repoWorkDir: -> @_getActiveRepo().getWorkingDirectory()
+  @_repoWorkDir: (filepath) -> @getActiveRepo(filepath).getWorkingDirectory()
 
-  @_repoGitDir: -> @_getActiveRepo().getPath()
+  @_repoGitDir: (filepath) -> @getActiveRepo(filepath).getPath()
 
   @_statusCodesFrom: (chunk, handler) ->
     for line in chunk.split("\n")

--- a/lib/git-bridge.coffee
+++ b/lib/git-bridge.coffee
@@ -70,11 +70,11 @@ class GitBridge
       exit: exitHandler
     }).onWillThrowError errorHandler
 
-  @getActivePath: ->
+  @_getActivePath: ->
     atom.workspace.getActivePaneItem()?.getPath?()
 
-  @getActiveRepo: ->
-    [rootDir] = atom.project.relativizePath @getActivePath()
+  @_getActiveRepo: ->
+    [rootDir] = atom.project.relativizePath @_getActivePath()
     if rootDir?
       rootDirIndex = atom.project.getPaths().indexOf(rootDir)
       repo = atom.project.getRepositories()[rootDirIndex]
@@ -82,9 +82,9 @@ class GitBridge
       repo = atom.project.getRepositories()[0]
     return repo
 
-  @_repoWorkDir: -> @getActiveRepo().getWorkingDirectory()
+  @_repoWorkDir: -> @_getActiveRepo().getWorkingDirectory()
 
-  @_repoGitDir: -> @getActiveRepo().getPath()
+  @_repoGitDir: -> @_getActiveRepo().getPath()
 
   @_statusCodesFrom: (chunk, handler) ->
     for line in chunk.split("\n")

--- a/lib/git-bridge.coffee
+++ b/lib/git-bridge.coffee
@@ -82,6 +82,15 @@ class GitBridge
       repo = atom.project.getRepositories()[0]
     return repo
 
+  # Public: Return a filepath relative to the git repository that contains it.
+  #
+  # * `filepath` {String} Absolute path to the file.
+  #
+  # Returns the relative path as a {String}, or null if the path isn't within a known repository.
+  #
+  @repoRelativePath: (filepath) ->
+    @getActiveRepo(filepath)?.relativize filepath
+
   @_repoWorkDir: (filepath) -> @getActiveRepo(filepath).getWorkingDirectory()
 
   @_repoGitDir: (filepath) -> @getActiveRepo(filepath).getPath()

--- a/lib/view/error-view.coffee
+++ b/lib/view/error-view.coffee
@@ -43,5 +43,6 @@ module.exports =
     if err instanceof GitNotFoundError
       atom.workspace.addTopPanel item: new GitNotFoundErrorView(err)
     else
-      console.error err
+      atom.notifications.addError err.message
+      console.error err.message, err.trace
     true

--- a/lib/view/merge-conflicts-view.coffee
+++ b/lib/view/merge-conflicts-view.coffee
@@ -142,7 +142,7 @@ class MergeConflictsView extends View
 
   stageFile: (event, element) ->
     repoPath = element.closest('li').data('path')
-    filePath = path.join GitBridge.getActiveRepo(repoPath).getWorkingDirectory(), repoPath
+    filePath = path.join GitBridge.getActiveRepo().getWorkingDirectory(), repoPath
 
     for e in atom.workspace.getTextEditors()
       e.save() if e.getPath() is filePath

--- a/lib/view/merge-conflicts-view.coffee
+++ b/lib/view/merge-conflicts-view.coffee
@@ -38,7 +38,7 @@ class MergeConflictsView extends View
     @subs = new CompositeDisposable
 
     @subs.add @pkg.onDidResolveConflict (event) =>
-      p = GitBridge.getActiveRepo().relativize event.file
+      p = GitBridge.getActiveRepo(event.file).relativize event.file
       found = false
       for listElement in @pathList.children()
         li = $(listElement)
@@ -62,7 +62,7 @@ class MergeConflictsView extends View
 
   navigate: (event, element) ->
     repoPath = element.find(".path").text()
-    fullPath = path.join GitBridge.getActiveRepo().getWorkingDirectory(), repoPath
+    fullPath = path.join GitBridge.getActiveRepo(repoPath).getWorkingDirectory(), repoPath
     atom.workspace.open(fullPath)
 
   minimize: ->
@@ -142,7 +142,7 @@ class MergeConflictsView extends View
 
   stageFile: (event, element) ->
     repoPath = element.closest('li').data('path')
-    filePath = path.join GitBridge.getActiveRepo().getWorkingDirectory(), repoPath
+    filePath = path.join GitBridge.getActiveRepo(repoPath).getWorkingDirectory(), repoPath
 
     for e in atom.workspace.getTextEditors()
       e.save() if e.getPath() is filePath
@@ -176,7 +176,7 @@ class MergeConflictsView extends View
     return if state.isEmpty()
 
     fullPath = editor.getPath()
-    repoPath = GitBridge.getActiveRepo()?.relativize fullPath
+    repoPath = GitBridge.getActiveRepo(fullPath)?.relativize fullPath
     return unless repoPath?
 
     return unless _.contains state.conflictPaths(), repoPath

--- a/lib/view/merge-conflicts-view.coffee
+++ b/lib/view/merge-conflicts-view.coffee
@@ -176,7 +176,9 @@ class MergeConflictsView extends View
     return if state.isEmpty()
 
     fullPath = editor.getPath()
-    repoPath = GitBridge.getActiveRepo().relativize fullPath
+    repoPath = GitBridge.getActiveRepo()?.relativize fullPath
+    return unless repoPath?
+
     return unless _.contains state.conflictPaths(), repoPath
 
     e = new ConflictedEditor(state, pkg, editor)

--- a/lib/view/merge-conflicts-view.coffee
+++ b/lib/view/merge-conflicts-view.coffee
@@ -38,7 +38,7 @@ class MergeConflictsView extends View
     @subs = new CompositeDisposable
 
     @subs.add @pkg.onDidResolveConflict (event) =>
-      p = GitBridge.getActiveRepo(event.file).relativize event.file
+      p = GitBridge.repoRelativePath event.file
       found = false
       for listElement in @pathList.children()
         li = $(listElement)
@@ -62,7 +62,7 @@ class MergeConflictsView extends View
 
   navigate: (event, element) ->
     repoPath = element.find(".path").text()
-    fullPath = path.join GitBridge.getActiveRepo(repoPath).getWorkingDirectory(), repoPath
+    fullPath = path.join GitBridge.getActiveRepo().getWorkingDirectory(), repoPath
     atom.workspace.open(fullPath)
 
   minimize: ->
@@ -176,7 +176,7 @@ class MergeConflictsView extends View
     return if state.isEmpty()
 
     fullPath = editor.getPath()
-    repoPath = GitBridge.getActiveRepo(fullPath)?.relativize fullPath
+    repoPath = GitBridge.repoRelativePath fullPath
     return unless repoPath?
 
     return unless _.contains state.conflictPaths(), repoPath


### PR DESCRIPTION
If the active Project has no git repositories, show a friendlier error message.

Fixes #129.