### PR TITLE
More multiple repository work.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 1.3.3
 
+- With multiple projects, remember the git repository that you initially detected conflicts within. [#165](https://github.com/smashwilson/merge-conflicts/pull/165)
 - Handle projects with no git repository. [#164](https://github.com/smashwilson/merge-conflicts/pull/164)
 - Improve the "Git not found" error dialog. [#163](https://github.com/smashwilson/merge-conflicts/pull/163)
 - Use alt-m instead of ctrl-m in key bindings. [#162](https://github.com/smashwilson/merge-conflicts/pull/162)

--- a/lib/conflicted-editor.coffee
+++ b/lib/conflicted-editor.coffee
@@ -102,7 +102,7 @@ class ConflictedEditor
   # Private: Event handler invoked when all conflicts in this file have been resolved.
   #
   conflictsResolved: ->
-    atom.workspace.addTopPanel item: new ResolverView(@editor, @pkg)
+    atom.workspace.addTopPanel item: new ResolverView(@editor, @state, @pkg)
 
   detectDirty: ->
     # Only detect dirty regions within CoveringViews that have a cursor within them.

--- a/lib/git-bridge.coffee
+++ b/lib/git-bridge.coffee
@@ -82,15 +82,6 @@ class GitBridge
       repo = atom.project.getRepositories()[0]
     return repo
 
-  # Public: Return a filepath relative to the git repository that contains it.
-  #
-  # * `filepath` {String} Absolute path to the file.
-  #
-  # Returns the relative path as a {String}, or null if the path isn't within a known repository.
-  #
-  @repoRelativePath: (filepath) ->
-    @getActiveRepo(filepath)?.relativize filepath
-
   @_repoWorkDir: (filepath) -> @getActiveRepo(filepath).getWorkingDirectory()
 
   @_repoGitDir: (filepath) -> @getActiveRepo(filepath).getPath()
@@ -114,7 +105,7 @@ class GitBridge
 
     return true
 
-  @withConflicts: (handler) ->
+  @withConflicts: (repo, handler) ->
     return unless @_checkHealth(handler)
 
     conflicts = []
@@ -140,7 +131,7 @@ class GitBridge
     proc = @process({
       command: GitCmd,
       args: ['status', '--porcelain'],
-      options: { cwd: @_repoWorkDir() },
+      options: { cwd: repo.getWorkingDirectory() },
       stdout: stdoutHandler,
       stderr: stderrHandler,
       exit: exitHandler

--- a/lib/merge-state.coffee
+++ b/lib/merge-state.coffee
@@ -2,26 +2,23 @@
 
 class MergeState
 
-  constructor: (@conflicts, @isRebase) ->
+  constructor: (@conflicts, @repo, @isRebase) ->
 
   conflictPaths: -> c.path for c in @conflicts
 
   reread: (callback) ->
-    GitBridge.withConflicts (err, @conflicts) =>
-      if err?
-        callback(err, null)
-      else
-        callback(null, this)
+    GitBridge.withConflicts @repo, (err, @conflicts) =>
+      callback(err, this)
 
   isEmpty: -> @conflicts.length is 0
 
-  @read: (callback) ->
+  @read: (repo, callback) ->
     isr = GitBridge.isRebasing()
-    GitBridge.withConflicts (err, cs) ->
+    GitBridge.withConflicts repo, (err, cs) ->
       if err?
         callback(err, null)
       else
-        callback(null, new MergeState(cs, isr))
+        callback(null, new MergeState(cs, repo, isr))
 
 module.exports =
   MergeState: MergeState

--- a/lib/view/merge-conflicts-view.coffee
+++ b/lib/view/merge-conflicts-view.coffee
@@ -158,8 +158,8 @@ class MergeConflictsView extends View
     repo = GitBridge.getActiveRepo()
     unless repo?
       atom.notifications.addWarning "No git repository found",
-        detail: "Tip: if you have multiple projects open, open an editor in the one"
-          "containing conflicts."
+        detail: "Tip: if you have multiple projects open, open an editor in the one
+          containing conflicts."
       return
 
     MergeState.read repo, (err, state) =>

--- a/lib/view/merge-conflicts-view.coffee
+++ b/lib/view/merge-conflicts-view.coffee
@@ -38,7 +38,7 @@ class MergeConflictsView extends View
     @subs = new CompositeDisposable
 
     @subs.add @pkg.onDidResolveConflict (event) =>
-      p = GitBridge.repoRelativePath event.file
+      p = @state.repo.relativize event.file
       found = false
       for listElement in @pathList.children()
         li = $(listElement)
@@ -153,10 +153,16 @@ class MergeConflictsView extends View
       @pkg.didStageFile file: filePath
 
   @detect: (pkg) ->
-    return unless atom.project.getRepositories().length > 0
     return if @instance?
 
-    MergeState.read (err, state) =>
+    repo = GitBridge.getActiveRepo()
+    unless repo?
+      atom.notifications.addWarning "No git repository found",
+        detail: "Tip: if you have multiple projects open, open an editor in the one"
+          "containing conflicts."
+      return
+
+    MergeState.read repo, (err, state) =>
       return if handleErr(err)
 
       if not state.isEmpty()
@@ -176,7 +182,7 @@ class MergeConflictsView extends View
     return if state.isEmpty()
 
     fullPath = editor.getPath()
-    repoPath = GitBridge.repoRelativePath fullPath
+    repoPath = state.repo.relativize fullPath
     return unless repoPath?
 
     return unless _.contains state.conflictPaths(), repoPath

--- a/lib/view/merge-conflicts-view.coffee
+++ b/lib/view/merge-conflicts-view.coffee
@@ -62,7 +62,7 @@ class MergeConflictsView extends View
 
   navigate: (event, element) ->
     repoPath = element.find(".path").text()
-    fullPath = path.join GitBridge.getActiveRepo().getWorkingDirectory(), repoPath
+    fullPath = path.join @state.repo.getWorkingDirectory(), repoPath
     atom.workspace.open(fullPath)
 
   minimize: ->

--- a/lib/view/resolver-view.coffee
+++ b/lib/view/resolver-view.coffee
@@ -8,7 +8,7 @@
 
 class ResolverView extends View
 
-  @content: (editor, pkg) ->
+  @content: (editor, state, pkg) ->
     @div class: 'overlay from-top resolver', =>
       @div class: 'block text-highlight', "We're done here"
       @div class: 'block', =>
@@ -22,7 +22,7 @@ class ResolverView extends View
       @div class: 'pull-right', =>
         @button class: 'btn btn-primary', click: 'resolve', 'Stage'
 
-  initialize: (@editor, @pkg) ->
+  initialize: (@editor, @state, @pkg) ->
     @subs = new CompositeDisposable()
 
     @refresh()
@@ -35,10 +35,10 @@ class ResolverView extends View
   getModel: -> null
 
   relativePath: ->
-    GitBridge.getActiveRepo().relativize @editor.getURI()
+    @state.repo.relativize @editor.getURI()
 
   refresh: ->
-    GitBridge.isStaged @relativePath(), (err, staged) =>
+    GitBridge.isStaged @state.repo, @relativePath(), (err, staged) =>
       return if handleErr(err)
 
       modified = @editor.isModified()
@@ -58,7 +58,7 @@ class ResolverView extends View
 
   resolve: ->
     @editor.save()
-    GitBridge.add @relativePath(), (err) =>
+    GitBridge.add @state.repo, @relativePath(), (err) =>
       return if handleErr(err)
 
       @refresh()

--- a/spec/conflicted-editor-spec.coffee
+++ b/spec/conflicted-editor-spec.coffee
@@ -52,6 +52,9 @@ describe 'ConflictedEditor', ->
         editor = editorView.getModel()
         state =
           isRebase: false
+          repo:
+            getWorkingDirectory: -> ""
+            relativize: (filepath) -> filepath
 
         m = new ConflictedEditor(state, pkg, editor)
         m.mark()
@@ -209,6 +212,9 @@ describe 'ConflictedEditor', ->
         editor = editorView.getModel()
         state =
           isRebase: true
+          repo:
+            getWorkingDirectory: -> ""
+            relativize: (filepath) -> filepath
 
         m = new ConflictedEditor(state, pkg, editor)
         m.mark()

--- a/spec/view/merge-conflicts-view-spec.coffee
+++ b/spec/view/merge-conflicts-view-spec.coffee
@@ -20,11 +20,20 @@ describe 'MergeConflictsView', ->
   beforeEach ->
     pkg = util.pkgEmitter()
 
+    GitBridge.process = ({exit}) ->
+      exit(0)
+      { process: { on: (err) -> }, onWillThrowError: -> }
+
+    done = false
+    GitBridge.locateGitAnd (err) -> done = true
+    waitsFor -> done
+
     conflicts = _.map ['file1.txt', 'file2.txt'], (fname) ->
       { path: repoPath(fname), message: 'both modified' }
 
     util.openPath 'triple-2way-diff.txt', (editorView) ->
-      state = new MergeState conflicts, false
+      repo = atom.project.getRepositories()[0]
+      state = new MergeState conflicts, repo, false
       conflicts = Conflict.all state, editorView.getModel()
 
       view = new MergeConflictsView(state, pkg)

--- a/spec/view/resolver-view-spec.coffee
+++ b/spec/view/resolver-view-spec.coffee
@@ -6,15 +6,19 @@ util = require '../util'
 describe 'ResolverView', ->
   [view, fakeEditor, pkg] = []
 
+  state =
+    repo:
+      getWorkingDirectory: -> "/fake/gitroot/"
+      relativize: (filepath) -> filepath["/fake/gitroot/".length..]
+
   beforeEach ->
     pkg = util.pkgEmitter()
     fakeEditor = {
       isModified: -> true
-      getURI: -> 'lib/file1.txt'
+      getURI: -> '/fake/gitroot/lib/file1.txt'
       save: ->
       onDidSave: ->
     }
-    view = new ResolverView(fakeEditor, pkg)
 
     atom.config.set('merge-conflicts.gitPath', 'git')
     done = false
@@ -28,6 +32,8 @@ describe 'ResolverView', ->
       stdout('UU lib/file1.txt')
       exit(0)
       { process: { on: (err) -> } }
+
+    view = new ResolverView(fakeEditor, state, pkg)
 
   it 'begins needing both saving and staging', ->
     view.refresh()
@@ -55,4 +61,4 @@ describe 'ResolverView', ->
     expect(fakeEditor.save).toHaveBeenCalled()
     expect(c).toBe('git')
     expect(a).toEqual(['add', 'lib/file1.txt'])
-    expect(o).toEqual({ cwd: atom.project.getRepositories()[0].getWorkingDirectory() })
+    expect(o).toEqual({ cwd: state.repo.getWorkingDirectory() })


### PR DESCRIPTION
This makes the repository that you initially detect conflicts within "sticky." This avoids a few problems with opening editors from other projects and trying to stage resolutions for files in different ones.