### PR TITLE
[wip] Scroll the individual conflict marker list.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 1.3.4
 
+- Scroll the merge conflicts view when many conflicts exist. [#170](https://github.com/smashwilson/merge-conflicts/pull/170)
+- Prune some dead code. [#167](https://github.com/smashwilson/merge-conflicts/pull/167)
+
 ## 1.3.3
 
 - With multiple projects, remember the git repository that you initially detected conflicts within. [#165](https://github.com/smashwilson/merge-conflicts/pull/165)

--- a/lib/view/merge-conflicts-view.coffee
+++ b/lib/view/merge-conflicts-view.coffee
@@ -20,18 +20,19 @@ class MergeConflictsView extends View
         @text 'Conflicts'
         @span class: 'pull-right icon icon-fold', click: 'minimize', 'Hide'
         @span class: 'pull-right icon icon-unfold', click: 'restore', 'Show'
-      @div class: 'conflict-list', outlet: 'body', =>
-        @ul class: 'block list-group', outlet: 'pathList', =>
-          for {path: p, message} in state.conflicts
-            @li click: 'navigate', "data-path": p, class: 'list-item navigate', =>
-              @span class: 'inline-block icon icon-diff-modified status-modified path', p
-              @div class: 'pull-right', =>
-                @button click: 'stageFile', class: 'btn btn-xs btn-success inline-block-tight stage-ready', style: 'display: none', 'Stage'
-                @span class: 'inline-block text-subtle', message
-                @progress class: 'inline-block', max: 100, value: 0
-                @span class: 'inline-block icon icon-dash staged'
-      @div class: 'footer block pull-right', =>
-        @button class: 'btn btn-sm', click: 'quit', 'Quit'
+      @div outlet: 'body', =>
+        @div class: 'conflict-list', =>
+          @ul class: 'block list-group', outlet: 'pathList', =>
+            for {path: p, message} in state.conflicts
+              @li click: 'navigate', "data-path": p, class: 'list-item navigate', =>
+                @span class: 'inline-block icon icon-diff-modified status-modified path', p
+                @div class: 'pull-right', =>
+                  @button click: 'stageFile', class: 'btn btn-xs btn-success inline-block-tight stage-ready', style: 'display: none', 'Stage'
+                  @span class: 'inline-block text-subtle', message
+                  @progress class: 'inline-block', max: 100, value: 0
+                  @span class: 'inline-block icon icon-dash staged'
+        @div class: 'footer block pull-right', =>
+          @button class: 'btn btn-sm', click: 'quit', 'Quit'
 
   initialize: (@state, @pkg) ->
     @subs = new CompositeDisposable

--- a/lib/view/merge-conflicts-view.coffee
+++ b/lib/view/merge-conflicts-view.coffee
@@ -20,7 +20,7 @@ class MergeConflictsView extends View
         @text 'Conflicts'
         @span class: 'pull-right icon icon-fold', click: 'minimize', 'Hide'
         @span class: 'pull-right icon icon-unfold', click: 'restore', 'Show'
-      @div outlet: 'body', =>
+      @div class: 'conflict-list', outlet: 'body', =>
         @ul class: 'block list-group', outlet: 'pathList', =>
           for {path: p, message} in state.conflicts
             @li click: 'navigate', "data-path": p, class: 'list-item navigate', =>
@@ -30,8 +30,8 @@ class MergeConflictsView extends View
                 @span class: 'inline-block text-subtle', message
                 @progress class: 'inline-block', max: 100, value: 0
                 @span class: 'inline-block icon icon-dash staged'
-        @div class: 'block pull-right', =>
-          @button class: 'btn btn-sm', click: 'quit', 'Quit'
+      @div class: 'footer block pull-right', =>
+        @button class: 'btn btn-sm', click: 'quit', 'Quit'
 
   initialize: (@state, @pkg) ->
     @subs = new CompositeDisposable

--- a/styles/merge-conflicts.less
+++ b/styles/merge-conflicts.less
@@ -1,6 +1,11 @@
 @import "variables";
 
 .merge-conflicts {
+  .conflict-list {
+    max-height: 150px;
+    overflow: scroll;
+  }
+
   .navigate {
     cursor: pointer;
 


### PR DESCRIPTION
Use a scrollbar when you have more conflicted files than can be comfortably shown in the bottom panel.

Fixes #138.