### PR TITLE
GitBridge.add expects a repo, not a path.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.5
+
+- Using the "stage" button no longer triggers a crash. [#173](https://github.com/smashwilson/merge-conflicts/pull/173)
+
 ## 1.3.4
 
 - Scroll the merge conflicts view when many conflicts exist. [#170](https://github.com/smashwilson/merge-conflicts/pull/170)

--- a/lib/view/merge-conflicts-view.coffee
+++ b/lib/view/merge-conflicts-view.coffee
@@ -144,7 +144,7 @@ class MergeConflictsView extends View
     for e in atom.workspace.getTextEditors()
       e.save() if e.getPath() is filePath
 
-    GitBridge.add repoPath, (err) =>
+    GitBridge.add @state.repo, repoPath, (err) =>
       return if handleErr(err)
 
       @pkg.didStageFile file: filePath


### PR DESCRIPTION
This fixes another "Undefined is not a function" bug that crops up when you use the stage button in the MergeConflictsView, as referenced in #169.