### PR TITLE
Fix selection highlight display

### DIFF
--- a/styles/variables.less
+++ b/styles/variables.less
@@ -1,9 +1,9 @@
 @import "ui-variables";
 
-@ours-line-color: mix(@ui-site-color-1, @base-background-color);
-@ours-current-color: darken(@ours-line-color, 10%);
-@theirs-line-color: mix(@ui-site-color-2, @base-background-color);
-@theirs-current-color: darken(@theirs-line-color, 10%);
-@dirty-line-color: darken(@ui-site-color-5, 40%);
-@dirty-current-color: darken(@ui-site-color-5, 30%);
+@ours-line-color: fade(@ui-site-color-1, 40%);
+@ours-current-color: fadeout(@ours-line-color, 10%);
+@theirs-line-color: fade(@ui-site-color-2, 40%);
+@theirs-current-color: fadeout(@theirs-line-color, 10%);
+@dirty-line-color: fade(@ui-site-color-5, 40%);
+@dirty-current-color: fadeout(@dirty-line-color, 10%);
 @resolved-line-color: @background-color-highlight;


### PR DESCRIPTION
Use transparency instead of mix() to allow selection to show through.
Reduce intensity slightly for better visibility.