### PR TITLE
verticallyScrollable is no longer a thing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.7
+
+- Update the method I was using to read the scrollbar width. [#190](https://github.com/smashwilson/merge-conflicts/pull/190)
+
 ## 1.3.6
 
 - Use transparency instead of `mix()` to allow selection to show through. [#181](https://github.com/smashwilson/merge-conflicts/pull/181)

--- a/lib/view/covering-view.coffee
+++ b/lib/view/covering-view.coffee
@@ -15,12 +15,8 @@ class CoveringView extends View
     @coverSubs.add @editor.onDidDestroy => @cleanup()
 
   attached: ->
-    rightPosition = if @editor.verticallyScrollable()
-        @editor.getVerticalScrollbarWidth()
-      else
-        0
-
-    @parent().css right: rightPosition
+    view = atom.views.getView(@editor)
+    @parent().css right: view.getVerticalScrollbarWidth()
 
     @css 'margin-top': -@editor.getLineHeightInPixels()
     @height @editor.getLineHeightInPixels()


### PR DESCRIPTION
This uses the `getVerticalScrollbarWidth` method on the element itself to avoid the removed and deprecated methods I was using before. Fixes #187, but imperfectly:

![screen shot 2015-11-02 at 2 34 19 pm](https://cloud.githubusercontent.com/assets/17565/10892023/4b223904-816f-11e5-8dd4-5901cc590a13.jpeg)

It looks like the scrollbar measurement is off somehow. I'd rather :shipit: this as-is because, well, at least it doesn't blow up on every package activation, even if it looks kind of funny.