### PR TITLE
feat(cli): create git merge compatible mergetool script

### DIFF
--- a/lib/atom_merge
+++ b/lib/atom_merge
@@ -1,0 +1,21 @@
+#!/bin/bash -e
+
+MERGED=${MERGED:-$1}
+if [ -z "${MERGED}" ] ; then
+  echo ERR
+  echo Need to have a file to merge
+  exit 1
+fi
+
+#Wait for changes on the merge file
+echo Watching for changes in ${MERGED}
+bash -c "while [ $(stat -f %c $MERGED) -eq \$(stat -f %c $MERGED) ] ; do sleep 1 ; done " &
+PID_CHANGED=$!
+
+#Spawn atom, pointed at the file to merge. Up to the user to edit
+echo Opening ${MERGED} in atom
+atom $MERGED &
+
+#Once the file has been saved, we assume merge is complete.
+#User will need to acknowledge in shell
+wait $PID_CHANGED

--- a/lib/mergetool.gitconfig
+++ b/lib/mergetool.gitconfig
@@ -1,0 +1,4 @@
+[merge]
+	tool = atom
+[mergetool "atom"]
+	cmd = atom_merge $MERGED


### PR DESCRIPTION
This addresses #43 

There's a simple script that spawns a wait loop and then throws the merge target into atom... you can then run merge-conflicts on that guy.

Once the file changes, the stat will update for the file, thus killing the script and git will throw up the next merge conflict. This can be very quick to use if you already have the repo open in atom, as you only need to run the merge-conflicts once, and then each file that atom opens will have the conflicts ready for you to change.

The only wuddyup I noticed was that env vars don't seem to be passed to bash atm... so I included a file ( `lib/mergetool.gitconfig` ) that should be sourceable for extending the local user's gitconfig.

As long as you get an absolute path for the atom_merge script or add it to the path, that guy should work fine... I probably won't have time to find a 'install' method for this script, but it does the heavy lifting. Maybe you could trick git into asking apm for a path to the merge-conflicts install dir?

Thoughts?