### PR TITLE
Add UI element for alternate resolution strategies like "Keep Both"

### DIFF
--- a/lib/view/side-view.coffee
+++ b/lib/view/side-view.coffee
@@ -11,6 +11,7 @@ class SideView extends CoveringView
         @span class: 'pull-right', =>
           @button class: 'btn btn-xs inline-block-tight revert', click: 'revert', outlet: 'revertBtn', 'Revert'
           @button class: 'btn btn-xs inline-block-tight', click: 'useMe', outlet: 'useMeBtn', 'Use Me'
+          ## TODO: re #185 add another @button here that provides alternate resolutions from `ConflictedEditor`, e.g. "Keep Both"
 
   initialize: (@side, editor) ->
     @subs = new CompositeDisposable


### PR DESCRIPTION
The plugin supports resolution via "Keep Both" methods `acceptOursThenTheirs()` and `acceptTheirsThenOurs()` but those options are "hidden" underneath the contextual menu (well, _I_ certainly never thought to right-click on the conflict). Provide a UI element -- like a gear button? -- that will supply other resolution options.

* Original issue: #185
* See [UI elements in `SideView`](../blob/master/lib/view/side-view.coffee#L7-L13): 
* See [resolution fns in `ConflictedEditor`](../blob/master/lib/conflicted-editor.coffee#L74-L81)