### PR TITLE
[wip] Use block decorations for CoveringViews

### DIFF
--- a/lib/view/covering-view.coffee
+++ b/lib/view/covering-view.coffee
@@ -8,17 +8,13 @@ class CoveringView extends View
   initialize: (@editor) ->
     @coverSubs = new CompositeDisposable
     @overlay = @editor.decorateMarker @cover(),
-      type: 'overlay',
+      type: 'block',
       item: this,
-      position: 'tail'
+      position: 'before'
 
     @coverSubs.add @editor.onDidDestroy => @cleanup()
 
   attached: ->
-    view = atom.views.getView(@editor)
-    @parent().css right: view.getVerticalScrollbarWidth()
-
-    @css 'margin-top': -@editor.getLineHeightInPixels()
     @height @editor.getLineHeightInPixels()
 
   cleanup: ->

--- a/styles/merge-conflicts.less
+++ b/styles/merge-conflicts.less
@@ -53,13 +53,9 @@
   .stage .text-success { display: none; }
 }
 
-// This targetting is temporary until SideViews work as overlay decorations.
-// See https://github.com/smashwilson/merge-conflicts/pull/93 for progress.
-atom-overlay {
+atom-text-editor.conflicted {
   .side {
     padding: 0 20px;
-    left: 0;
-    right: 0;
 
     span {
       margin-left: 10px;


### PR DESCRIPTION
Atom's [block decorations](http://blog.atom.io/2016/02/03/introducing-block-decorations.html) seem like a good fit for rendering the merge controls within TextEditors, but they aren't quite there yet. I think I'll need support for a `position: "replace"` before I can fully cut over gracefully.