### PR TITLE
Fix hangs with broken conflict marker

### DIFF
--- a/lib/conflict.coffee
+++ b/lib/conflict.coffee
@@ -9,7 +9,7 @@ CONFLICT_REGEX = ///
   ^<{7}\ (.+)\r?\n([^]*?)
   # Base side may contain nested conflict markers.
   # Refer: http://stackoverflow.com/questions/16990657/git-merge-diff3-style-need-explanation
-  (?:\|{7}\ (.+)\r?\n((?:(?:<{7}[^]*?>{7})|[^]*?)*?))?
+  (?:\|{7}\ (.+)\r?\n((?:(?:<{7}[^]*?>{7})|[^])*?))?
   ={7}\r?\n([^]*?)
   >{7}\ (.+)(?:\r?\n)?
   ///mg


### PR DESCRIPTION
Sorry but previous PR #219 caused hang with below snippet...

```
<<<<<<< HEAD
    AAA
||||||| merged common ancestors
    BBB
>>>>>>> origin/master
```

It seems related to backtracking of regexp.