### PR TITLE
Register custom repository contexts

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ subs.dispose()
 ```
 
  * `onDidResolveConflict`: broadcast whenever a conflict is resolved. `event.file`: the absolute path of the file in which the conflict was found; `event.total`: the total number of conflicts in that file; `event.resolved`: the number of conflicts that are resolved, including this one.
- * `onDidStageFile`: broadcast whenever a file has been completed and staged for commit. `event.file`: the absolute path of the file that was staged.
+ * `onDidResolveFile`: broadcast whenever a file has been completed and staged for commit. `event.file`: the absolute path of the file that was staged.
  * `onDidQuitConflictResolution`: broadcast when you stop merging conflicts by clicking the quit button.
  * `onDidCompleteConflictResolution`: broadcast when all conflicts in all files have successfully been resolved.
 

--- a/lib/git/common.js
+++ b/lib/git/common.js
@@ -2,22 +2,32 @@
 
 // Utilities shared among git backends.
 
-exports.getActiveRepo = function (filePath) {
+exports.getActiveGitRepo = function (filePath) {
+  if (!filePath) {
+    filePath = getActivePath();
+  }
   let dirs = atom.project.getDirectories();
   let repos = atom.project.getRepositories();
   for (let i = 0; i < dirs.length; i++) {
     let d = dirs[i];
-    if (d.contains(filePath)) {
-      return Promise.resolve(repos[i]);
+    if (d.contains(filePath) && isGitRepo(repos[i])) {
+      return Promise.resolve({
+        repository: repos[i],
+        priority: 3,
+      });
     }
   }
 
-  if (repos.length < 1) {
-    return Promise.resolve(null);
-  }
-
-  return Promise.resolve(repos[0]);
+  const firstGitRepo = repos.filter(isGitRepo)[0];
+  return Promise.resolve(firstGitRepo == null ? null : {
+    repository: firstGitRepo,
+    priority: 2,
+  });
 };
+
+function isGitRepo(repo) {
+  return repo != null && repo.getType() === 'git';
+}
 
 let getActivePath = function () {
   let paneItem = atom.workspace.getActivePaneItem();

--- a/lib/git/gitops.js
+++ b/lib/git/gitops.js
@@ -33,6 +33,7 @@ function GitContext(repository, workingDirPath, priority) {
   this.workingDirPath = workingDirPath;
   this.workingDirectory = new Directory(workingDirPath, false);
   this.priority = priority;
+  this.resolveText = "Stage";
 }
 
 GitContext.prototype.readConflicts = function () {

--- a/lib/git/gitops.js
+++ b/lib/git/gitops.js
@@ -55,7 +55,7 @@ GitContext.prototype.readConflicts = function () {
     })
 };
 
-GitContext.prototype.isStaged = function (filePath) {
+GitContext.prototype.isResolvedFile = function (filePath) {
   return this.repository.getStatus()
     .then((statuses) => statuses.some((status) => {
       return status.path() === filePath && status.isModified();
@@ -80,7 +80,7 @@ GitContext.prototype.checkoutSide = function (sideName, filePath) {
   });
 };
 
-GitContext.prototype.resolve = function (filePath) {
+GitContext.prototype.resolveFile = function (filePath) {
   return this.repository.index()
     .then((i) => {
       let result = i.addByPath(filePath);

--- a/lib/git/gitops.js
+++ b/lib/git/gitops.js
@@ -8,28 +8,31 @@ let Checkout = Git.Checkout;
 let Directory = a.Directory;
 let common = require("./common");
 
-exports.getGitContext = function (filePath) {
+exports.getContext = function (filePath) {
   let wd = null;
 
-  return common.getActiveRepo(filePath)
-    .then((atomRepo) => {
-      if (!atomRepo) return null;
+  return common.getActiveGitRepo(filePath)
+    .then((repoDetails) => {
+      if (!repoDetails) return null;
 
-      wd = atomRepo.getWorkingDirectory();
+      const {repository, priority} = repoDetails;
+
+      wd = repository.getWorkingDirectory();
 
       return Git.Repository.open(wd);
     })
     .then((nodegitRepo) => {
       if (!nodegitRepo) return null;
 
-      return new GitContext(nodegitRepo, wd);
+      return new GitContext(nodegitRepo, wd, priority);
     });
 };
 
-function GitContext(repository, workingDirPath) {
+function GitContext(repository, workingDirPath, priority) {
   this.repository = repository;
   this.workingDirPath = workingDirPath;
   this.workingDirectory = new Directory(workingDirPath, false);
+  this.priority = priority;
 }
 
 GitContext.prototype.readConflicts = function () {
@@ -77,7 +80,7 @@ GitContext.prototype.checkoutSide = function (sideName, filePath) {
   });
 };
 
-GitContext.prototype.add = function (filePath) {
+GitContext.prototype.resolve = function (filePath) {
   return this.repository.index()
     .then((i) => {
       let result = i.addByPath(filePath);
@@ -92,3 +95,7 @@ GitContext.prototype.add = function (filePath) {
 GitContext.prototype.isRebasing = function () {
   return this.repository.isRebasing();
 };
+
+GitContext.prototype.joinPath = function(relativePath) {
+  return path.join(this.workingDirPath, relativePath);
+}

--- a/lib/git/shellout.js
+++ b/lib/git/shellout.js
@@ -32,6 +32,7 @@ function GitContext(repository, gitCmd, workingDirPath, priority) {
   this.workingDirectory = new Directory(workingDirPath, false);
   this.runProcess = (args) => new BufferedProcess(args);
   this.priority = priority;
+  this.resolveText = "Stage";
 };
 
 GitContext.prototype.readConflicts = function () {
@@ -45,7 +46,6 @@ GitContext.prototype.readConflicts = function () {
           conflicts.push({
             path: p,
             message: "both modified",
-            resolveMessage: "Stage",
           });
         }
 
@@ -53,7 +53,6 @@ GitContext.prototype.readConflicts = function () {
           conflicts.push({
             path: p,
             message: "both added",
-            resolveMessage: "Stage",
           });
         }
       });

--- a/lib/git/shellout.js
+++ b/lib/git/shellout.js
@@ -10,26 +10,28 @@ let path = require("path");
 
 let common = require("./common");
 
-exports.getGitContext = function (filePath) {
-  return Promise.all([locateGit(), common.getActiveRepo(filePath)])
+exports.getContext = function (filePath) {
+  return Promise.all([locateGit(), common.getActiveGitRepo(filePath)])
     .then((results) => {
-      let gitCmd = results[0];
-      let atomRepo = results[1];
+      const gitCmd = results[0];
+      const repoDetails = results[1];
 
-      if (!gitCmd) return null;
-      if (!atomRepo) return null;
+      if (!gitCmd || !repoDetails) return null;
 
-      let wd = atomRepo.getWorkingDirectory();
-      return new GitContext(atomRepo, gitCmd, wd);
+      const repository = repoDetails.repository;
+      const priority = repoDetails.priority;
+      let wd = repository.getWorkingDirectory();
+      return new GitContext(repository, gitCmd, wd, priority);
     });
 };
 
-function GitContext(repository, gitCmd, workingDirPath) {
+function GitContext(repository, gitCmd, workingDirPath, priority) {
   this.repository = repository;
   this.gitCmd = gitCmd;
   this.workingDirPath = workingDirPath;
   this.workingDirectory = new Directory(workingDirPath, false);
   this.runProcess = (args) => new BufferedProcess(args);
+  this.priority = priority;
 };
 
 GitContext.prototype.readConflicts = function () {
@@ -42,14 +44,16 @@ GitContext.prototype.readConflicts = function () {
         if (index === "U" && work === "U") {
           conflicts.push({
             path: p,
-            message: "both modified"
+            message: "both modified",
+            resolveMessage: "Stage",
           });
         }
 
         if (index === "A" && work === "A") {
           conflicts.push({
             path: p,
-            message: "both added"
+            message: "both added",
+            resolveMessage: "Stage",
           });
         }
       });
@@ -134,7 +138,7 @@ GitContext.prototype.checkoutSide = function (sideName, filePath) {
   });
 };
 
-GitContext.prototype.add = function (filePath) {
+GitContext.prototype.resolve = function (filePath) {
   this.repository.repo.add(filePath);
   return Promise.resolve();
 };
@@ -228,3 +232,7 @@ let statusCodesFrom = function (chunk, handler) {
     }
   });
 };
+
+GitContext.prototype.joinPath = function(relativePath) {
+  return path.join(this.workingDirPath, relativePath);
+}

--- a/lib/git/shellout.js
+++ b/lib/git/shellout.js
@@ -82,7 +82,7 @@ GitContext.prototype.readConflicts = function () {
   });
 };
 
-GitContext.prototype.isStaged = function (filePath) {
+GitContext.prototype.isResolvedFile = function (filePath) {
   let staged = true;
 
   return new Promise((resolve, reject) => {
@@ -138,7 +138,7 @@ GitContext.prototype.checkoutSide = function (sideName, filePath) {
   });
 };
 
-GitContext.prototype.resolve = function (filePath) {
+GitContext.prototype.resolveFile = function (filePath) {
   this.repository.repo.add(filePath);
   return Promise.resolve();
 };

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -4,6 +4,7 @@
 {GitOps} = require './git'
 
 pkgEmitter = null;
+pkgApi = null;
 
 module.exports =
 
@@ -58,9 +59,19 @@ module.exports =
   onDidCompleteConflictResolution: (callback) ->
     @emitter.on 'did-complete-conflict-resolution', callback
 
+  # Register a repository context provider that will have functionality for
+  # retrieving and resolving conflicts.
+  #
+  registerContextApi: (contextApi) ->
+    MergeConflictsView.registerContextApi(contextApi)
+
   provideApi: ->
-    _ = require 'underscore-plus'
-    _.extend({}, pkgEmitter, {
-      registerContextApi: (contextApi) =>
-        MergeConflictsView.registerContextApi(contextApi);
-    });
+    if (pkgApi == null)
+      pkgApi = Object.freeze({
+        registerContextApi: @registerContextApi,
+        onDidResolveConflict: pkgEmitter.onDidResolveConflict,
+        onDidResolveFile: pkgEmitter.onDidResolveConflict,
+        onDidQuitConflictResolution: pkgEmitter.onDidQuitConflictResolution,
+        onDidCompleteConflictResolution: pkgEmitter.onDidCompleteConflictResolution,
+      })
+    pkgApi

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -1,13 +1,17 @@
 {CompositeDisposable, Emitter} = require 'atom'
 
 {MergeConflictsView} = require './view/merge-conflicts-view'
-{handleErr} = require './view/error-view'
+{GitOps} = require './git'
+
+pkgEmitter = null;
 
 module.exports =
 
   activate: (state) ->
     @subs = new CompositeDisposable
     @emitter = new Emitter
+
+    MergeConflictsView.registerContextApi(GitOps);
 
     pkgEmitter =
       onDidResolveConflict: (callback) => @onDidResolveConflict(callback)
@@ -53,3 +57,10 @@ module.exports =
   #
   onDidCompleteConflictResolution: (callback) ->
     @emitter.on 'did-complete-conflict-resolution', callback
+
+  provideApi: ->
+    _ = require 'underscore-plus'
+    _.extend({}, pkgEmitter, {
+      registerContextApi: (contextApi) =>
+        MergeConflictsView.registerContextApi(contextApi);
+    });

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -16,8 +16,8 @@ module.exports =
     pkgEmitter =
       onDidResolveConflict: (callback) => @onDidResolveConflict(callback)
       didResolveConflict: (event) => @emitter.emit 'did-resolve-conflict', event
-      onDidStageFile: (callback) => @onDidStageFile(callback)
-      didStageFile: (event) => @emitter.emit 'did-stage-file', event
+      onDidResolveFile: (callback) => @onDidResolveFile(callback)
+      didResolveFile: (event) => @emitter.emit 'did-resolve-file', event
       onDidQuitConflictResolution: (callback) => @onDidQuitConflictResolution(callback)
       didQuitConflictResolution: => @emitter.emit 'did-quit-conflict-resolution'
       onDidCompleteConflictResolution: (callback) => @onDidCompleteConflictResolution(callback)
@@ -41,10 +41,10 @@ module.exports =
   onDidResolveConflict: (callback) ->
     @emitter.on 'did-resolve-conflict', callback
 
-  # Invoke a callback each time that a completed file is staged.
+  # Invoke a callback each time that a completed file is resolved.
   #
-  onDidStageFile: (callback) ->
-    @emitter.on 'did-stage-file', callback
+  onDidResolveFile: (callback) ->
+    @emitter.on 'did-resolve-file', callback
 
   # Invoke a callback if conflict resolution is prematurely exited, while conflicts remain
   # unresolved.
@@ -53,7 +53,7 @@ module.exports =
     @emitter.on 'did-quit-conflict-resolution', callback
 
   # Invoke a callback if conflict resolution is completed successfully, with all conflicts resolved
-  # and all files staged.
+  # and all files resolved.
   #
   onDidCompleteConflictResolution: (callback) ->
     @emitter.on 'did-complete-conflict-resolution', callback

--- a/lib/merge-state.coffee
+++ b/lib/merge-state.coffee
@@ -1,5 +1,3 @@
-path = require 'path'
-
 class MergeState
 
   constructor: (@conflicts, @context, @isRebase) ->
@@ -17,7 +15,7 @@ class MergeState
 
   relativize: (filePath) -> @context.workingDirectory.relativize filePath
 
-  join: (relativePath) -> path.join @context.workingDirPath, relativePath
+  join: (relativePath) -> @context.joinPath(relativePath)
 
   @read: (context, callback) ->
     isr = context.isRebasing()

--- a/lib/view/merge-conflicts-view.coffee
+++ b/lib/view/merge-conflicts-view.coffee
@@ -26,7 +26,7 @@ class MergeConflictsView extends View
               @li click: 'navigate', "data-path": p, class: 'list-item navigate', =>
                 @span class: 'inline-block icon icon-diff-modified status-modified path', p
                 @div class: 'pull-right', =>
-                  @button click: 'stageFile', class: 'btn btn-xs btn-success inline-block-tight stage-ready', style: 'display: none', resolveMessage
+                  @button click: 'resolveFile', class: 'btn btn-xs btn-success inline-block-tight stage-ready', style: 'display: none', resolveMessage
                   @span class: 'inline-block text-subtle', message
                   @progress class: 'inline-block', max: 100, value: 0
                   @span class: 'inline-block icon icon-dash staged'
@@ -53,7 +53,7 @@ class MergeConflictsView extends View
       unless found
         console.error "Unrecognized conflict path: #{p}"
 
-    @subs.add @pkg.onDidStageFile => @refresh()
+    @subs.add @pkg.onDidResolveFile => @refresh()
 
     @subs.add atom.commands.add @element,
       'merge-conflicts:entire-file-ours': @sideResolver('ours'),
@@ -136,16 +136,16 @@ class MergeConflictsView extends View
       .catch (err) ->
         handleErr(err)
 
-  stageFile: (event, element) ->
+  resolveFile: (event, element) ->
     repoPath = element.closest('li').data('path')
     filePath = @state.join repoPath
 
     for e in atom.workspace.getTextEditors()
       e.save() if e.getPath() is filePath
 
-    @state.context.resolve(repoPath)
+    @state.context.resolveFile(repoPath)
     .then =>
-      @pkg.didStageFile file: filePath
+      @pkg.didResolveFile file: filePath
     .catch (err) ->
       handleErr(err)
 

--- a/lib/view/merge-conflicts-view.coffee
+++ b/lib/view/merge-conflicts-view.coffee
@@ -129,7 +129,7 @@ class MergeConflictsView extends View
     (event) =>
       p = $(event.target).closest('li').data('path')
       @state.context.checkoutSide(side, p)
-      .then ->
+      .then =>
         full = @state.join p
         @pkg.didResolveConflict file: full, total: 1, resolved: 1
         atom.workspace.open p

--- a/lib/view/merge-conflicts-view.coffee
+++ b/lib/view/merge-conflicts-view.coffee
@@ -22,11 +22,11 @@ class MergeConflictsView extends View
       @div outlet: 'body', =>
         @div class: 'conflict-list', =>
           @ul class: 'block list-group', outlet: 'pathList', =>
-            for {path: p, message, resolveMessage} in state.conflicts
+            for {path: p, message} in state.conflicts
               @li click: 'navigate', "data-path": p, class: 'list-item navigate', =>
                 @span class: 'inline-block icon icon-diff-modified status-modified path', p
                 @div class: 'pull-right', =>
-                  @button click: 'resolveFile', class: 'btn btn-xs btn-success inline-block-tight stage-ready', style: 'display: none', resolveMessage
+                  @button click: 'resolveFile', class: 'btn btn-xs btn-success inline-block-tight stage-ready', style: 'display: none', state.context.resolveText
                   @span class: 'inline-block text-subtle', message
                   @progress class: 'inline-block', max: 100, value: 0
                   @span class: 'inline-block icon icon-dash staged'
@@ -112,7 +112,7 @@ class MergeConflictsView extends View
           detail += '"git commit" at will to finish the merge.'
 
         @finish ->
-          atom.notifications.addSuccess "Merge Complete",
+          atom.notifications.addSuccess "All Conflicts Resolved",
             detail: detail,
             dismissable: true
 

--- a/lib/view/resolver-view.coffee
+++ b/lib/view/resolver-view.coffee
@@ -55,7 +55,7 @@ class ResolverView extends View
 
   resolve: ->
     @editor.save()
-    @state.context.add @relativePath()
+    @state.context.resolve @relativePath()
     .then =>
       @refresh()
     .catch handleErr

--- a/lib/view/resolver-view.coffee
+++ b/lib/view/resolver-view.coffee
@@ -35,7 +35,7 @@ class ResolverView extends View
     @state.relativize @editor.getURI()
 
   refresh: ->
-    @state.context.isStaged @relativePath()
+    @state.context.isResolvedFile @relativePath()
     .then (staged) =>
       modified = @editor.isModified()
 
@@ -44,7 +44,7 @@ class ResolverView extends View
 
       unless needsSaved or needsStaged
         @hide 'fast', => @remove()
-        @pkg.didStageFile file: @editor.getURI()
+        @pkg.didResolveFile file: @editor.getURI()
         return
 
       if needsSaved
@@ -55,7 +55,7 @@ class ResolverView extends View
 
   resolve: ->
     @editor.save()
-    @state.context.resolve @relativePath()
+    @state.context.resolveFile @relativePath()
     .then =>
       @refresh()
     .catch handleErr

--- a/lib/view/resolver-view.coffee
+++ b/lib/view/resolver-view.coffee
@@ -6,18 +6,19 @@
 class ResolverView extends View
 
   @content: (editor, state, pkg) ->
+    resolveText = state.context.resolveText
     @div class: 'overlay from-top resolver', =>
       @div class: 'block text-highlight', "We're done here"
       @div class: 'block', =>
         @div class: 'block text-info', =>
           @text "You've dealt with all of the conflicts in this file."
         @div class: 'block text-info', =>
-          @span outlet: 'actionText', 'Save and stage'
-          @text ' this file for commit?'
+          @span outlet: 'actionText', "Save and #{resolveText}"
+          @text ' this file?'
       @div class: 'pull-left', =>
         @button class: 'btn btn-primary', click: 'dismiss', 'Maybe Later'
       @div class: 'pull-right', =>
-        @button class: 'btn btn-primary', click: 'resolve', 'Stage'
+        @button class: 'btn btn-primary', click: 'resolve', resolveText
 
   initialize: (@editor, @state, @pkg) ->
     @subs = new CompositeDisposable()
@@ -36,29 +37,31 @@ class ResolverView extends View
 
   refresh: ->
     @state.context.isResolvedFile @relativePath()
-    .then (staged) =>
+    .then (resolved) =>
       modified = @editor.isModified()
 
       needsSaved = modified
-      needsStaged = modified or not staged
+      needsResolve = modified or not resolved
 
-      unless needsSaved or needsStaged
+      unless needsSaved or needsResolve
         @hide 'fast', => @remove()
         @pkg.didResolveFile file: @editor.getURI()
         return
 
+      resolveText = @state.context.resolveText
       if needsSaved
-        @actionText.text 'Save and stage'
-      else if needsStaged
-        @actionText.text 'Stage'
+        @actionText.text "Save and #{resolveText.toLowerCase()}"
+      else if needsResolve
+        @actionText.text resolveText
     .catch handleErr
 
   resolve: ->
-    @editor.save()
-    @state.context.resolveFile @relativePath()
-    .then =>
-      @refresh()
-    .catch handleErr
+    # Suport async save implementations.
+    Promise.resolve(@editor.save()).then =>
+      @state.context.resolveFile @relativePath()
+      .then =>
+        @refresh()
+      .catch handleErr
 
   dismiss: ->
     @hide 'fast', => @remove()

--- a/package.json
+++ b/package.json
@@ -7,11 +7,6 @@
   "contributors": [
     "Maximilian Schüßler <maximilian@mschuessler.org>"
   ],
-  "activationCommands": {
-    "atom-workspace": [
-      "merge-conflicts:detect"
-    ]
-  },
   "repository": "https://github.com/smashwilson/merge-conflicts",
   "license": "MIT",
   "engines": {
@@ -20,5 +15,13 @@
   "dependencies": {
     "space-pen": "^5.0.1",
     "underscore-plus": "1.x"
+  },
+  "providedServices": {
+    "merge-conflicts": {
+      "description": "Register conflict resolver integrations",
+      "versions": {
+        "0.0.0": "provideApi"
+      }
+    }
   }
 }

--- a/spec/conflicted-editor-spec.coffee
+++ b/spec/conflicted-editor-spec.coffee
@@ -46,7 +46,7 @@ describe 'ConflictedEditor', ->
           isRebase: false
           relativize: (filepath) -> filepath
           context:
-            isStaged: (filepath) -> Promise.resolve false
+            isResolvedFile: (filepath) -> Promise.resolve false
 
         m = new ConflictedEditor(state, pkg, editor)
         m.mark()
@@ -206,7 +206,7 @@ describe 'ConflictedEditor', ->
           isRebase: true
           relativize: (filepath) -> filepath
           context:
-            isStaged: -> Promise.resolve(false)
+            isResolvedFile: -> Promise.resolve(false)
 
         m = new ConflictedEditor(state, pkg, editor)
         m.mark()

--- a/spec/git-shellout-spec.coffee
+++ b/spec/git-shellout-spec.coffee
@@ -12,7 +12,7 @@ describe 'GitBridge', ->
     atom.config.set('merge-conflicts.gitPath', '/usr/bin/git')
 
     waitsForPromise ->
-      GitOps.getGitContext()
+      GitOps.getContext()
       .then (c) ->
         context = c
         context.workingDirPath = gitWorkDir
@@ -37,8 +37,8 @@ describe 'GitBridge', ->
 
     runs ->
       expect(conflicts).toEqual([
-        { path: 'lib/file0.rb', message: 'both modified' }
-        { path: 'lib/file1.rb', message: 'both added' }
+        { path: 'lib/file0.rb', message: 'both modified', resolveMessage : 'Stage' }
+        { path: 'lib/file1.rb', message: 'both added', resolveMessage : 'Stage' }
       ])
       expect(c).toBe('/usr/bin/git')
       expect(a).toEqual(['status', '--porcelain'])
@@ -89,7 +89,7 @@ describe 'GitBridge', ->
 
     called = false
     waitsForPromise ->
-      context.add('lib/file1.txt').then -> called = true
+      context.resolve('lib/file1.txt').then -> called = true
 
     runs ->
       expect(called).toBe(true)

--- a/spec/git-shellout-spec.coffee
+++ b/spec/git-shellout-spec.coffee
@@ -44,7 +44,7 @@ describe 'GitBridge', ->
       expect(a).toEqual(['status', '--porcelain'])
       expect(o).toEqual({ cwd: gitWorkDir })
 
-  describe 'isStaged', ->
+  describe 'isResolvedFile', ->
 
     statusMeansStaged = (status, checkPath = 'lib/file2.txt') ->
       context.mockProcess ({stdout, exit}) ->
@@ -52,7 +52,7 @@ describe 'GitBridge', ->
         exit(0)
         { process: { on: (callback) -> } }
 
-      context.isStaged(checkPath)
+      context.isResolvedFile(checkPath)
 
     it 'is true if already resolved', ->
       waitsForPromise -> statusMeansStaged('M ').then (s) -> expect(s).toBe(true)
@@ -89,7 +89,7 @@ describe 'GitBridge', ->
 
     called = false
     waitsForPromise ->
-      context.resolve('lib/file1.txt').then -> called = true
+      context.resolveFile('lib/file1.txt').then -> called = true
 
     runs ->
       expect(called).toBe(true)

--- a/spec/git-shellout-spec.coffee
+++ b/spec/git-shellout-spec.coffee
@@ -37,8 +37,8 @@ describe 'GitBridge', ->
 
     runs ->
       expect(conflicts).toEqual([
-        { path: 'lib/file0.rb', message: 'both modified', resolveMessage : 'Stage' }
-        { path: 'lib/file1.rb', message: 'both added', resolveMessage : 'Stage' }
+        { path: 'lib/file0.rb', message: 'both modified'}
+        { path: 'lib/file1.rb', message: 'both added'}
       ])
       expect(c).toBe('/usr/bin/git')
       expect(a).toEqual(['status', '--porcelain'])

--- a/spec/util.coffee
+++ b/spec/util.coffee
@@ -19,8 +19,8 @@ module.exports =
     return {
       onDidResolveConflict: (callback) -> emitter.on 'did-resolve-conflict', callback
       didResolveConflict: (event) -> emitter.emit 'did-resolve-conflict', event
-      onDidStageFile: (callback) -> emitter.on 'did-stage-file', callback
-      didStageFile: (event) -> emitter.emit 'did-stage-file', event
+      onDidResolveFile: (callback) -> emitter.on 'did-resolve-file', callback
+      didResolveFile: (event) -> emitter.emit 'did-resolve-file', event
       onDidQuitConflictResolution: (callback) -> emitter.on 'did-quit-conflict-resolution', callback
       didQuitConflictResolution: -> emitter.emit 'did-quit-conflict-resolution'
       onDidCompleteConflictResolution: (callback) -> emitter.on 'did-complete-conflict-resolution', callback

--- a/spec/view/merge-conflicts-view-spec.coffee
+++ b/spec/view/merge-conflicts-view-spec.coffee
@@ -72,7 +72,7 @@ describe 'MergeConflictsView', ->
     it 'marks files as staged on events', ->
       context.readConflicts = -> Promise.resolve([{ path: repoPath("file2.txt"), message: "both modified"}])
 
-      pkg.didStageFile file: fullPath('file1.txt')
+      pkg.didResolveFile file: fullPath('file1.txt')
 
       # Terrible hack.
       waitsFor -> isMarkedWith 'file1.txt', 'check'

--- a/spec/view/resolver-view-spec.coffee
+++ b/spec/view/resolver-view-spec.coffee
@@ -8,8 +8,8 @@ describe 'ResolverView', ->
 
   state =
     context:
-      isStaged: -> Promise.resolve false
-      resolve: ->
+      isResolvedFile: -> Promise.resolve false
+      resolveFile: ->
     relativize: (filepath) -> filepath["/fake/gitroot/".length..]
 
   beforeEach ->
@@ -34,7 +34,7 @@ describe 'ResolverView', ->
 
   it 'saves and stages the file', ->
     p = null
-    state.context.resolve = (filepath) ->
+    state.context.resolveFile = (filepath) ->
       p = filepath
       Promise.resolve()
 

--- a/spec/view/resolver-view-spec.coffee
+++ b/spec/view/resolver-view-spec.coffee
@@ -9,7 +9,7 @@ describe 'ResolverView', ->
   state =
     context:
       isStaged: -> Promise.resolve false
-      add: ->
+      resolve: ->
     relativize: (filepath) -> filepath["/fake/gitroot/".length..]
 
   beforeEach ->
@@ -34,7 +34,7 @@ describe 'ResolverView', ->
 
   it 'saves and stages the file', ->
     p = null
-    state.context.add = (filepath) ->
+    state.context.resolve = (filepath) ->
       p = filepath
       Promise.resolve()
 

--- a/spec/view/resolver-view-spec.coffee
+++ b/spec/view/resolver-view-spec.coffee
@@ -10,6 +10,7 @@ describe 'ResolverView', ->
     context:
       isResolvedFile: -> Promise.resolve false
       resolveFile: ->
+      resolveText: "Stage"
     relativize: (filepath) -> filepath["/fake/gitroot/".length..]
 
   beforeEach ->


### PR DESCRIPTION
In [Nuclide](http://nuclide.io/), we need to integrate such an awesome package for our mercurial repository (which currently doesn't come without all of nuclide).

Here are the changes I needed to do to get it working:
* **Service API**: Following Atom's [New Service API](http://blog.atom.io/2015/03/25/new-services-API.html), followed by Nuclide, I made the `merge-conflicts` compatible with that service API to register custom contexts.
* **Code**: The `Stage` term is specific to git, changed to `ResolveFile`
* **UI**: The hardcoded `Stage` message in the UI is also git-specific --> changed to a context-specifc `resolveText`
* **Priority**: Since you can easily have multiple roots with multiple repositories in an Atom window, the priority goes to the active file path and comes context-specific, because for example, in Nuclide, we have a current working directory feature that prioritizes a root over the others (hence, the need to make it context-specific).

Coming after:
* Provide `merge-conflict` APIs for auto-detection of conflicting state (now happens in our mercurial repo) and quitting / hiding the UI from outside.
* Custom final message: `git rebase --continue` with context-specific logic / message.
* Automate running the rebase / merge command to finish all of the rebase / merge within Atom.
* As bits of this gets done for mercurial, it will be pushed to https://github.com/facebook/nuclide