### PR TITLE
Avoid "Use me" <atom-overlay> to scroll over conflicts panel

### DIFF
--- a/styles/merge-conflicts.less
+++ b/styles/merge-conflicts.less
@@ -1,6 +1,9 @@
 @import "variables";
 
 .merge-conflicts {
+  position: relative;
+  z-index: 10;
+
   .conflict-list {
     max-height: 150px;
     overflow: scroll;


### PR DESCRIPTION
Scrolling a large file with conflicts shows the "Use-me" overlays over the "conflicts" panel:

![screen shot 2016-05-17 at 12 30 43](https://cloud.githubusercontent.com/assets/743894/15319462/434b8846-1c2b-11e6-855f-ca09ae99684d.png)

This can be easily solved by increasing the z-index from the "Conflicts panel". I added the `position: relative;` too to avoid possible breaks if the tag `<atom-panel />` ever gets its `position: relative;` removed.