### PR TITLE
Normalize paths coming from git

### DIFF
--- a/lib/git/shellout.js
+++ b/lib/git/shellout.js
@@ -44,14 +44,14 @@ GitContext.prototype.readConflicts = function () {
       statusCodesFrom(chunk, (index, work, p) => {
         if (index === "U" && work === "U") {
           conflicts.push({
-            path: p,
+            path: path.normalize(p),
             message: "both modified",
           });
         }
 
         if (index === "A" && work === "A") {
           conflicts.push({
-            path: p,
+            path: path.normalize(p),
             message: "both added",
           });
         }
@@ -87,7 +87,7 @@ GitContext.prototype.isResolvedFile = function (filePath) {
   return new Promise((resolve, reject) => {
     let stdoutHandler = (chunk) => {
       statusCodesFrom(chunk, (index, work, p) => {
-        if (p === filePath) {
+        if (path.normalize(p) === filePath) {
           staged = index === "M" && work === " ";
         }
       });
@@ -138,7 +138,8 @@ GitContext.prototype.checkoutSide = function (sideName, filePath) {
 };
 
 GitContext.prototype.resolveFile = function (filePath) {
-  this.repository.repo.add(filePath);
+  // git-utils wants paths with forward slashes. relativize takes care of that.
+  this.repository.repo.add(this.repository.repo.relativize(filePath));
   return Promise.resolve();
 };
 


### PR DESCRIPTION
On windows, paths may have forward or backward slashes. git under fake
unix environments in windows, like msys2, produces paths with forward
slashes.

We need to normalize those paths as they come out of git, so path
comparisons with atom paths (using backward slashes) work. Without this,
merge-conflict fails to mark conflicts on files in subdirectories due
to wrong slashes.

Additionally, it turns out that node's git-utils package wants forward
slashes. So, for git-utils methods, we use relativize on paths to convert
them to something git-utils likes.

This may fix #227 and #228.

I tried to test whether nodegit handles well windows paths, but atom errors
out with `USE_NODEGIT=1`. Is nodegit available on atom 1.7.x? Would we have
slash problems for windows there?