### PR TITLE
Custom repository contexts: show, hide, complete, quit and multi-context projects

### DIFF
--- a/lib/git/common.js
+++ b/lib/git/common.js
@@ -29,11 +29,37 @@ function isGitRepo(repo) {
   return repo != null && repo.getType() === 'git';
 }
 
-let getActivePath = function () {
+function getActivePath() {
   let paneItem = atom.workspace.getActivePaneItem();
 
   if (!paneItem) return null;
   if (!paneItem.getPath) return null;
 
   return paneItem.getPath();
+}
+
+exports.quitContext = function (wasRebasing) {
+  let detail = "Careful, you've still got conflict markers left!\n";
+  if (wasRebasing)
+    detail += '"git rebase --abort"';
+  else
+    detail += '"git merge --abort"';
+  detail += " if you just want to give up on this one.";
+  atom.notifications.addWarning("Maybe Later", {
+    detail: detail,
+    dismissable: true,
+  });
+}
+
+exports.completeContext = function (wasRebasing) {
+  let detail = "That's everything. ";
+  if (wasRebasing)
+    detail += '"git rebase --continue" at will to resume rebasing.';
+  else
+    detail += '"git commit" at will to finish the merge.';
+
+  atom.notifications.addSuccess("All Conflicts Resolved", {
+    detail: detail,
+    dismissable: true,
+  });
 }

--- a/lib/git/gitops.js
+++ b/lib/git/gitops.js
@@ -100,3 +100,11 @@ GitContext.prototype.isRebasing = function () {
 GitContext.prototype.joinPath = function(relativePath) {
   return path.join(this.workingDirPath, relativePath);
 }
+
+GitContext.prototype.quit = function(wasRebasing) {
+  common.quitContext(wasRebasing);
+}
+
+GitContext.prototype.complete = function(wasRebasing) {
+  common.completeContext(wasRebasing);
+}

--- a/lib/git/shellout.js
+++ b/lib/git/shellout.js
@@ -236,3 +236,11 @@ let statusCodesFrom = function (chunk, handler) {
 GitContext.prototype.joinPath = function(relativePath) {
   return path.join(this.workingDirPath, relativePath);
 }
+
+GitContext.prototype.quit = function(wasRebasing) {
+  common.quitContext(wasRebasing);
+}
+
+GitContext.prototype.complete = function(wasRebasing) {
+  common.completeContext(wasRebasing);
+}

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -65,10 +65,19 @@ module.exports =
   registerContextApi: (contextApi) ->
     MergeConflictsView.registerContextApi(contextApi)
 
+
+  showForContext: (context) ->
+    MergeConflictsView.showForContext(context, pkgEmitter)
+
+  hideForContext: (context) ->
+    MergeConflictsView.hideForContext(context)
+
   provideApi: ->
     if (pkgApi == null)
       pkgApi = Object.freeze({
         registerContextApi: @registerContextApi,
+        showForContext: @showForContext,
+        hideForContext: @hideForContext,
         onDidResolveConflict: pkgEmitter.onDidResolveConflict,
         onDidResolveFile: pkgEmitter.onDidResolveConflict,
         onDidQuitConflictResolution: pkgEmitter.onDidQuitConflictResolution,

--- a/lib/merge-state.coffee
+++ b/lib/merge-state.coffee
@@ -5,7 +5,7 @@ class MergeState
   conflictPaths: -> c.path for c in @conflicts
 
   reread: ->
-    @context.readConflicts().then (@conflicts) ->
+    @context.readConflicts().then (@conflicts) =>
 
   isEmpty: -> @conflicts.length is 0
 

--- a/lib/merge-state.coffee
+++ b/lib/merge-state.coffee
@@ -4,12 +4,8 @@ class MergeState
 
   conflictPaths: -> c.path for c in @conflicts
 
-  reread: (callback) ->
-    @context.readConflicts()
-    .then (@conflicts) =>
-      callback(null, this)
-    .catch (err) =>
-      callback(err, this)
+  reread: ->
+    @context.readConflicts().then (@conflicts) ->
 
   isEmpty: -> @conflicts.length is 0
 
@@ -17,13 +13,10 @@ class MergeState
 
   join: (relativePath) -> @context.joinPath(relativePath)
 
-  @read: (context, callback) ->
+  @read: (context) ->
     isr = context.isRebasing()
-    context.readConflicts()
-    .then (cs) ->
-      callback(null, new MergeState(cs, context, isr))
-    .catch (err) ->
-      callback(err, null)
+    context.readConflicts().then (cs) ->
+      new MergeState(cs, context, isr)
 
 module.exports =
   MergeState: MergeState

--- a/lib/view/merge-conflicts-view.coffee
+++ b/lib/view/merge-conflicts-view.coffee
@@ -74,18 +74,8 @@ class MergeConflictsView extends View
 
   quit: ->
     @pkg.didQuitConflictResolution()
-
-    detail = "Careful, you've still got conflict markers left!\n"
-    if @state.isRebase
-      detail += '"git rebase --abort"'
-    else
-      detail += '"git merge --abort"'
-    detail += " if you just want to give up on this one."
-
     @finish()
-    atom.notifications.addWarning "Maybe Later",
-      detail: detail
-      dismissable: true
+    @state.context.quit(@state.isRebase)
 
   refresh: ->
     @state.reread().catch(handleErr).then =>
@@ -100,19 +90,10 @@ class MergeConflictsView extends View
           icon.addClass 'icon-check text-success'
           @pathList.find("li[data-path='#{p}'] .stage-ready").hide()
 
-      if @state.isEmpty()
-        @pkg.didCompleteConflictResolution()
-
-        detail = "That's everything. "
-        if @state.isRebase
-          detail += '"git rebase --continue" at will to resume rebasing.'
-        else
-          detail += '"git commit" at will to finish the merge.'
-
-        @finish()
-        atom.notifications.addSuccess "All Conflicts Resolved",
-          detail: detail,
-          dismissable: true
+      return unless @state.isEmpty()
+      @pkg.didCompleteConflictResolution()
+      @finish()
+      @state.context.complete(@state.isRebase)
 
   finish: ->
     @subs.dispose()

--- a/lib/view/merge-conflicts-view.coffee
+++ b/lib/view/merge-conflicts-view.coffee
@@ -82,15 +82,13 @@ class MergeConflictsView extends View
       detail += '"git merge --abort"'
     detail += " if you just want to give up on this one."
 
-    @finish ->
-      atom.notifications.addWarning "Maybe Later",
-        detail: detail
-        dismissable: true
+    @finish()
+    atom.notifications.addWarning "Maybe Later",
+      detail: detail
+      dismissable: true
 
   refresh: ->
-    @state.reread (err, state) =>
-      return if handleErr(err)
-
+    @state.reread().catch(handleErr).then =>
       # Any files that were present, but aren't there any more, have been resolved.
       for item in @pathList.find('li')
         p = $(item).data('path')
@@ -111,19 +109,16 @@ class MergeConflictsView extends View
         else
           detail += '"git commit" at will to finish the merge.'
 
-        @finish ->
-          atom.notifications.addSuccess "All Conflicts Resolved",
-            detail: detail,
-            dismissable: true
+        @finish()
+        atom.notifications.addSuccess "All Conflicts Resolved",
+          detail: detail,
+          dismissable: true
 
-  finish: (andThen) ->
+  finish: ->
     @subs.dispose()
-
     @hide 'fast', =>
       MergeConflictsView.instance = null
       @remove()
-
-    andThen()
 
   sideResolver: (side) ->
     (event) =>
@@ -152,36 +147,47 @@ class MergeConflictsView extends View
   @registerContextApi: (contextApi) ->
     @contextApis.push(contextApi)
 
+  @showForContext: (context, pkg) ->
+    if @instance
+      @instance.finish()
+    MergeState.read(context).then (state) =>
+      return if state.isEmpty()
+      @openForState(state, pkg)
+    .catch handleErr
+
+  @hideForContext: (context) ->
+    return unless @instance
+    return unless @instance.state.context == context
+    @instance.finish()
+
   @detect: (pkg) ->
     return if @instance?
 
     Promise.all(@contextApis.map (contextApi) => contextApi.getContext())
     .then (contexts) =>
       # filter out nulls and take the highest priority context.
-      context = (
+      Promise.all(
         _.filter(contexts, Boolean)
         .sort (context1, context2) => context2.priority - context1.priority
-      )[0];
-      unless context?
-        atom.notifications.addWarning "No repository context found",
-          detail: "Tip: if you have multiple projects open, open an editor in the one
-            containing conflicts."
+        .map (context) => MergeState.read context
+      )
+    .then (states) =>
+      state = states.find (state) -> not state.isEmpty()
+      unless state?
+        atom.notifications.addInfo "Nothing to Merge",
+          detail: "No conflicts here!",
+          dismissable: true
         return
+      @openForState(state, pkg)
+    .catch handleErr
 
-      MergeState.read context, (err, state) =>
-        return if handleErr(err)
+  @openForState: (state, pkg) ->
+    view = new MergeConflictsView(state, pkg)
+    @instance = view
+    atom.workspace.addBottomPanel item: view
 
-        if not state.isEmpty()
-          view = new MergeConflictsView(state, pkg)
-          @instance = view
-          atom.workspace.addBottomPanel item: view
-
-          @instance.subs.add atom.workspace.observeTextEditors (editor) =>
-            @markConflictsIn state, editor, pkg
-        else
-          atom.notifications.addInfo "Nothing to Merge",
-            detail: "No conflicts here!",
-            dismissable: true
+    @instance.subs.add atom.workspace.observeTextEditors (editor) =>
+      @markConflictsIn state, editor, pkg
 
   @markConflictsIn: (state, editor, pkg) ->
     return if state.isEmpty()


### PR DESCRIPTION
This extends #222 to support custom repository (hg in that case) detection of going into and out of rebase/merge conflict state and requesting to show or hide the merge conflicts UI accordingly.

These changes support multiple context providers & activating for the one with the highest priority that is indeed in a conflicting state.

Finally, it changes the `complete` & `quit` to be context-specific so that can be defined from Nuclide side to support automation of running the appropriate commands and remote development.

callback-to-promise and some minor simplifications are along the lines.

I'll be sharing the flow types defined for `merge-conflicts` APIs when I finish my changes on the nuclide side.