### PR TITLE
Fixes deprecation call to assign custom properties to a marker #262

### DIFF
--- a/lib/conflict.js
+++ b/lib/conflict.js
@@ -153,7 +153,6 @@ const BOTTOM = 'bottom'
 
 // Options used to initialize markers.
 const options = {
-  persistent: false,
   invalidate: 'never'
 }
 


### PR DESCRIPTION
**Persistent** property was removed in Atom v1.9.0 and it generates deprecation warnings.
