### PR TITLE
Support custom project path for conflict detection

### DIFF
--- a/lib/git/common.js
+++ b/lib/git/common.js
@@ -10,7 +10,9 @@ exports.getActiveGitRepo = function (filePath) {
   let repos = atom.project.getRepositories();
   for (let i = 0; i < dirs.length; i++) {
     let d = dirs[i];
-    if (d.contains(filePath) && isGitRepo(repos[i])) {
+
+    /* To be compatible with the case where the path may be git root path. */
+    if ((d.contains(filePath) || d.getPath() == filePath) && isGitRepo(repos[i])) {
       return Promise.resolve({
         repository: repos[i],
         priority: 3,

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -7,7 +7,9 @@ pkgEmitter = null;
 pkgApi = null;
 
 module.exports =
-
+  detect: (filePath) ->
+    # Support custom project path for conflict detection
+    MergeConflictsView.detect(pkgEmitter,filePath)
   activate: (state) ->
     @subs = new CompositeDisposable
     @emitter = new Emitter
@@ -24,8 +26,8 @@ module.exports =
       onDidCompleteConflictResolution: (callback) => @onDidCompleteConflictResolution(callback)
       didCompleteConflictResolution: => @emitter.emit 'did-complete-conflict-resolution'
 
-    @subs.add atom.commands.add 'atom-workspace', 'merge-conflicts:detect', ->
-      MergeConflictsView.detect(pkgEmitter)
+    @subs.add atom.commands.add 'atom-workspace', 'merge-conflicts:detect', =>
+      @detect()
 
   deactivate: ->
     @subs.dispose()

--- a/lib/view/merge-conflicts-view.coffee
+++ b/lib/view/merge-conflicts-view.coffee
@@ -140,11 +140,10 @@ class MergeConflictsView extends View
     return unless @instance
     return unless @instance.state.context == context
     @instance.finish()
-
-  @detect: (pkg) ->
+  @detect: (pkg,filePath) ->
     return if @instance?
 
-    Promise.all(@contextApis.map (contextApi) => contextApi.getContext())
+    Promise.all(@contextApis.map (contextApi) => contextApi.getContext(filePath))
     .then (contexts) =>
       # filter out nulls and take the highest priority context.
       Promise.all(


### PR DESCRIPTION
Support custom project path for conflict detection And To be compatible
with the case where the path may be git root path.

Give other package author the ablity to programmed detection confilct.

usage:

```js
atom.packages.getActivePackage('merge-conflicts').mainModule.detect(someGitRepoPath)
``` 