### PR TITLE
Add setting to skip stage

### DIFF
--- a/lib/conflicted-editor.coffee
+++ b/lib/conflicted-editor.coffee
@@ -86,11 +86,10 @@ class ConflictedEditor
       'merge-conflicts:revert-current': => @revertCurrent()
 
     @subs.add @pkg.onDidResolveConflict ({total, resolved, file}) =>
-      if atom.config.get("merge-conflicts.skipStage")
-        if total == 0
+      if atom.config.get("merge-conflicts.skipStage") and total is 0
           @cleanup()
       if file is @editor.getPath() and total is resolved
-        if  total != 0
+        if atom.config.get("merge-conflicts.skipStage") and total isnt 0
           atom.notifications.addSuccess("All conflicts in file resolved. Remember to save the file.")
         @conflictsResolved()
 

--- a/lib/conflicted-editor.coffee
+++ b/lib/conflicted-editor.coffee
@@ -7,7 +7,6 @@ _ = require 'underscore-plus'
 {SideView} = require './view/side-view'
 {NavigationView} = require './view/navigation-view'
 {ResolverView} = require './view/resolver-view'
-{MergeConflictsView} = require './view/merge-conflicts-view'
 
 # Public: Mediate conflict-related decorations and events on behalf of a specific TextEditor.
 #
@@ -45,9 +44,7 @@ class ConflictedEditor
       @subs.add c.onDidResolveConflict =>
         unresolved = (v for v in @coveringViews when not v.conflict().isResolved())
         resolvedCount = @conflicts.length - Math.floor(unresolved.length / 3)
-        atom.notifications.addSuccess("ConflictedEditor 3")
         if atom.config.get("merge-conflicts.skipStage") and @conflicts.length is resolvedCount
-          atom.notifications.addSuccess("ConflictedEditor 8")
           @state.setResolved()
         @pkg.didResolveConflict
           file: @editor.getPath(),
@@ -62,13 +59,11 @@ class ConflictedEditor
       @focusConflict @conflicts[0]
     else
       if atom.config.get("merge-conflicts.skipStage")
-        atom.notifications.addSuccess("ConflictedEditor 7")
         @state.setResolved()
       @pkg.didResolveConflict
         file: @editor.getPath(),
         total: 1, resolved: 1,
         source: this
-      atom.notifications.addSuccess("ConflictedEditor 1")
       @conflictsResolved()
 
   # Private: Install Atom commands related to Conflict resolution and navigation on the TextEditor.
@@ -92,18 +87,12 @@ class ConflictedEditor
 
     @subs.add @pkg.onDidResolveConflict ({total, resolved, file}) =>
       if atom.config.get("merge-conflicts.skipStage")
-        # return unless not @state.isResolved()
-        atom.notifications.addSuccess("ConflictedEditor 5")
         if total == 0
-          atom.notifications.addSuccess("ConflictedEditor 6")
           @cleanup()
-      atom.notifications.addSuccess("ConflictedEditor 4")
       if file is @editor.getPath() and total is resolved
         if  total != 0
           atom.notifications.addSuccess("All conflicts in file resolved. Remember to save the file.")
-        atom.notifications.addSuccess("ConflictedEditor 2")
         @conflictsResolved()
-      atom.notifications.addSuccess("ConflictedEditor 10")
 
     @subs.add @pkg.onDidCompleteConflictResolution => @cleanup()
     @subs.add @pkg.onDidQuitConflictResolution => @cleanup()
@@ -115,8 +104,6 @@ class ConflictedEditor
 
     for c in @conflicts
       m.destroy() for m in c.markers()
-
-    atom.notifications.addSuccess("ConflictedEditor 9")
 
     v.remove() for v in @coveringViews
 

--- a/lib/conflicted-editor.coffee
+++ b/lib/conflicted-editor.coffee
@@ -7,6 +7,7 @@ _ = require 'underscore-plus'
 {SideView} = require './view/side-view'
 {NavigationView} = require './view/navigation-view'
 {ResolverView} = require './view/resolver-view'
+{MergeConflictsView} = require './view/merge-conflicts-view'
 
 # Public: Mediate conflict-related decorations and events on behalf of a specific TextEditor.
 #
@@ -44,6 +45,10 @@ class ConflictedEditor
       @subs.add c.onDidResolveConflict =>
         unresolved = (v for v in @coveringViews when not v.conflict().isResolved())
         resolvedCount = @conflicts.length - Math.floor(unresolved.length / 3)
+        atom.notifications.addSuccess("ConflictedEditor 3")
+        if atom.config.get("merge-conflicts.skipStage") and @conflicts.length is resolvedCount
+          atom.notifications.addSuccess("ConflictedEditor 8")
+          @state.setResolved()
         @pkg.didResolveConflict
           file: @editor.getPath(),
           total: @conflicts.length, resolved: resolvedCount,
@@ -56,10 +61,14 @@ class ConflictedEditor
       @installEvents()
       @focusConflict @conflicts[0]
     else
+      if atom.config.get("merge-conflicts.skipStage")
+        atom.notifications.addSuccess("ConflictedEditor 7")
+        @state.setResolved()
       @pkg.didResolveConflict
         file: @editor.getPath(),
         total: 1, resolved: 1,
         source: this
+      atom.notifications.addSuccess("ConflictedEditor 1")
       @conflictsResolved()
 
   # Private: Install Atom commands related to Conflict resolution and navigation on the TextEditor.
@@ -82,8 +91,19 @@ class ConflictedEditor
       'merge-conflicts:revert-current': => @revertCurrent()
 
     @subs.add @pkg.onDidResolveConflict ({total, resolved, file}) =>
+      if atom.config.get("merge-conflicts.skipStage")
+        # return unless not @state.isResolved()
+        atom.notifications.addSuccess("ConflictedEditor 5")
+        if total == 0
+          atom.notifications.addSuccess("ConflictedEditor 6")
+          @cleanup()
+      atom.notifications.addSuccess("ConflictedEditor 4")
       if file is @editor.getPath() and total is resolved
+        if  total != 0
+          atom.notifications.addSuccess("All conflicts in file resolved. Remember to save the file.")
+        atom.notifications.addSuccess("ConflictedEditor 2")
         @conflictsResolved()
+      atom.notifications.addSuccess("ConflictedEditor 10")
 
     @subs.add @pkg.onDidCompleteConflictResolution => @cleanup()
     @subs.add @pkg.onDidQuitConflictResolution => @cleanup()
@@ -96,6 +116,8 @@ class ConflictedEditor
     for c in @conflicts
       m.destroy() for m in c.markers()
 
+    atom.notifications.addSuccess("ConflictedEditor 9")
+
     v.remove() for v in @coveringViews
 
     @subs.dispose()
@@ -103,7 +125,8 @@ class ConflictedEditor
   # Private: Event handler invoked when all conflicts in this file have been resolved.
   #
   conflictsResolved: ->
-    atom.workspace.addTopPanel item: new ResolverView(@editor, @state, @pkg)
+    if not atom.config.get("merge-conflicts.skipStage")
+      atom.workspace.addTopPanel item: new ResolverView(@editor, @state, @pkg)
 
   detectDirty: ->
     # Only detect dirty regions within CoveringViews that have a cursor within them.

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -36,6 +36,10 @@ module.exports =
       type: 'string'
       default: ''
       description: 'Absolute path to your git executable.'
+    skipStage:
+      description: "Skip all stage functionality"
+      type: 'boolean'
+      default: false
 
   # Invoke a callback each time that an individual conflict is resolved.
   #

--- a/lib/merge-state.coffee
+++ b/lib/merge-state.coffee
@@ -1,6 +1,7 @@
 class MergeState
 
   constructor: (@conflicts, @context, @isRebase) ->
+    @nResolved = 0
 
   conflictPaths: -> c.path for c in @conflicts
 
@@ -12,6 +13,14 @@ class MergeState
   relativize: (filePath) -> @context.workingDirectory.relativize filePath
 
   join: (relativePath) -> @context.joinPath(relativePath)
+
+  showResolved: ->
+      atom.notifications.addSuccess("MergeState #{@conflicts.length} #{@nResolved}")
+
+  isResolved: -> @conflicts.length is @nResolved
+
+
+  setResolved: -> @nResolved = @nResolved + 1
 
   @read: (context) ->
     isr = context.isRebasing()

--- a/lib/view/merge-conflicts-view.coffee
+++ b/lib/view/merge-conflicts-view.coffee
@@ -45,7 +45,7 @@ class MergeConflictsView extends View
           found = true
 
           progress = li.find('progress')[0]
-          if event.total is 0
+          if atom.config.get("merge-conflicts.skipStage") and event.total is 0
             progress.max = 1
             progress.value = 1
           else
@@ -53,12 +53,12 @@ class MergeConflictsView extends View
             progress.value = event.resolved
 
           if event.total is event.resolved
-            if not atom.config.get("merge-conflicts.skipStage")
-              li.find('.stage-ready').show()
-            else
+            if atom.config.get("merge-conflicts.skipStage")
               icon = li.find('.staged')
               icon.removeClass 'icon-dash icon-check text-success'
               icon.addClass 'icon-check text-success'
+            else
+              li.find('.stage-ready').show()
 
       unless found
         console.error "Unrecognized conflict path: #{p}"
@@ -120,7 +120,9 @@ class MergeConflictsView extends View
         full = @state.join p
         if atom.config.get("merge-conflicts.skipStage")
           @state.setResolved()
-        @pkg.didResolveConflict file: full, total: 0, resolved: 0
+          @pkg.didResolveConflict file: full, total: 0, resolved: 0
+        else
+          @pkg.didResolveConflict file: full, total: 1, resolved: 1
         atom.workspace.open p
       .catch (err) ->
         handleErr(err)

--- a/lib/view/merge-conflicts-view.coffee
+++ b/lib/view/merge-conflicts-view.coffee
@@ -39,7 +39,6 @@ class MergeConflictsView extends View
     @subs.add @pkg.onDidResolveConflict (event) =>
       p = @state.relativize event.file
       found = false
-      atom.notifications.addSuccess("MergeConflictsView 5")
       for listElement in @pathList.children()
         li = $(listElement)
         if li.data('path') is p
@@ -63,16 +62,6 @@ class MergeConflictsView extends View
 
       unless found
         console.error "Unrecognized conflict path: #{p}"
-
-      atom.notifications.addSuccess("MergeConflictsView 6")
-
-      @state.showResolved()
-
-      if @state.isResolved()
-        atom.notifications.addSuccess("MergeConflictsView 7")
-        # @pkg.didCompleteConflictResolution()
-        # @finish()
-        # @state.context.complete(@state.isRebase)
 
 
     @subs.add @pkg.onDidResolveFile => @refresh()
@@ -107,16 +96,12 @@ class MergeConflictsView extends View
         icon = $(item).find('.staged')
         icon.removeClass 'icon-dash icon-check text-success'
         if _.contains @state.conflictPaths(), p
-          atom.notifications.addSuccess("MergeConflictsView 3")
           icon.addClass 'icon-dash'
         else
-          atom.notifications.addSuccess("MergeConflictsView 4")
           icon.addClass 'icon-check text-success'
           @pathList.find("li[data-path='#{p}'] .stage-ready").hide()
 
-      atom.notifications.addSuccess("MergeConflictsView 1")
       return unless @state.isEmpty()
-      atom.notifications.addSuccess("MergeConflictsView 2")
       @pkg.didCompleteConflictResolution()
       @finish()
       @state.context.complete(@state.isRebase)
@@ -134,7 +119,6 @@ class MergeConflictsView extends View
       .then =>
         full = @state.join p
         if atom.config.get("merge-conflicts.skipStage")
-          atom.notifications.addSuccess("MergeConflictsView 8")
           @state.setResolved()
         @pkg.didResolveConflict file: full, total: 0, resolved: 0
         atom.workspace.open p


### PR DESCRIPTION
This is a very early attempt to add support to skip the stage part of Merge Conflicts.

All changes connected to MergeState is a second part planned to do a "CompleteConflictResolution" without doing the stage part. I have not managed to get that part working yet.

The change in sideResolver (class MergeConflictsView) is a quick&dirty fix to (as I see it) an existing problem.

So in the end there are quite few changes so far connected to the added "Skip Stage" functionality.
The reason for this change is the plan to use merge-conflicts together with GitHub Desktop.
In some cases you lose the possibility to commit in GitHub Desktop if the change is staged.
